### PR TITLE
Export intents by default without type

### DIFF
--- a/src/cmd/mapper/mapper-export.go
+++ b/src/cmd/mapper/mapper-export.go
@@ -71,7 +71,6 @@ var ExportCmd = &cobra.Command{
 
 				for _, serviceIntent := range serviceIntents.Intents {
 					intent := v1alpha1.Intent{
-						Type: v1alpha1.IntentTypeHTTP,
 						Name: serviceIntent.Name,
 					}
 					if len(serviceIntent.Namespace) != 0 {

--- a/src/pkg/intentsprinter/printer.go
+++ b/src/pkg/intentsprinter/printer.go
@@ -25,7 +25,9 @@ spec:
   calls:
 {{- range $intent := .Spec.Calls }}
     - name: {{ $intent.Name }}
+{{- if $intent.Type }}
       type: {{ $intent.Type }}
+{{- end }}
 {{- if ne $intent.Namespace "" }}
       namespace: {{ $intent.Namespace }}
 {{- end -}}


### PR DESCRIPTION
### Description

This PR remove the default value of HTTP from intent type since it's no longer mandatory to have type for every intent, and by default intents should come without type
