### PR TITLE
bump api - Replace /objects/one endpoint with /object

### DIFF
--- a/src/cmd/environments/create/create-env.go
+++ b/src/cmd/environments/create/create-env.go
@@ -21,13 +21,16 @@ var CreateEnvCmd = &cobra.Command{
 		ctxTimeout, cancel := context.WithTimeout(context.Background(), config.DefaultTimeout)
 		defer cancel()
 
-		c := cloudclient.NewClientFromToken(viper.GetString(config.OtterizeAPIAddressKey), config.GetAPIToken(ctxTimeout))
+		c, err := cloudclient.NewClientFromToken(viper.GetString(config.OtterizeAPIAddressKey), config.GetAPIToken(ctxTimeout))
+		if err != nil {
+			return err
+		}
 
 		name := viper.GetString(NameKey)
 		labels := viper.GetStringMapString(LabelsKey)
 		labelsInput := lo.Ternary(len(labels) == 0, nil, lo.ToPtr(cloudclient.LabelsToLabelInput(labels)))
 
-		r, err := c.Client.CreateEnvironmentMutationWithResponse(ctxTimeout,
+		r, err := c.CreateEnvironmentMutationWithResponse(ctxTimeout,
 			cloudapi.CreateEnvironmentMutationJSONRequestBody{
 				Name:   name,
 				Labels: labelsInput,

--- a/src/cmd/environments/delete/delete-env.go
+++ b/src/cmd/environments/delete/delete-env.go
@@ -21,12 +21,15 @@ var DeleteEnvCmd = &cobra.Command{
 	RunE: func(_ *cobra.Command, args []string) error {
 		ctxTimeout, cancel := context.WithTimeout(context.Background(), config.DefaultTimeout)
 		defer cancel()
-		c := cloudclient.NewClientFromToken(viper.GetString(config.OtterizeAPIAddressKey), config.GetAPIToken(ctxTimeout))
+		c, err := cloudclient.NewClientFromToken(viper.GetString(config.OtterizeAPIAddressKey), config.GetAPIToken(ctxTimeout))
+		if err != nil {
+			return err
+		}
 
 		id := args[0]
 		force := viper.GetBool(ForceKey)
 
-		r, err := c.Client.DeleteEnvironmentMutationWithResponse(ctxTimeout, id,
+		r, err := c.DeleteEnvironmentMutationWithResponse(ctxTimeout, id,
 			&cloudapi.DeleteEnvironmentMutationParams{Force: &force},
 		)
 		if err != nil {

--- a/src/cmd/environments/get/get-env.go
+++ b/src/cmd/environments/get/get-env.go
@@ -21,11 +21,14 @@ var GetEnvCmd = &cobra.Command{
 		ctxTimeout, cancel := context.WithTimeout(context.Background(), config.DefaultTimeout)
 		defer cancel()
 
-		c := cloudclient.NewClientFromToken(viper.GetString(config.OtterizeAPIAddressKey), config.GetAPIToken(ctxTimeout))
+		c, err := cloudclient.NewClientFromToken(viper.GetString(config.OtterizeAPIAddressKey), config.GetAPIToken(ctxTimeout))
+		if err != nil {
+			return err
+		}
 
 		id := args[0]
 
-		r, err := c.Client.EnvironmentQueryWithResponse(ctxTimeout, id)
+		r, err := c.EnvironmentQueryWithResponse(ctxTimeout, id)
 		if err != nil {
 			return err
 		}

--- a/src/cmd/environments/list/list-envs.go
+++ b/src/cmd/environments/list/list-envs.go
@@ -20,13 +20,16 @@ var ListEnvsCmd = &cobra.Command{
 		ctxTimeout, cancel := context.WithTimeout(context.Background(), config.DefaultTimeout)
 		defer cancel()
 
-		c := cloudclient.NewClientFromToken(viper.GetString(config.OtterizeAPIAddressKey), config.GetAPIToken(ctxTimeout))
+		c, err := cloudclient.NewClientFromToken(viper.GetString(config.OtterizeAPIAddressKey), config.GetAPIToken(ctxTimeout))
+		if err != nil {
+			return err
+		}
 
 		name := viper.GetString(NameKey)
 		labels := viper.GetStringMapString(LabelsKey)
 		labelsInput := lo.Ternary(len(labels) == 0, nil, lo.ToPtr(cloudclient.LabelsToLabelInput(labels)))
 
-		r, err := c.Client.EnvironmentsQueryWithResponse(ctxTimeout,
+		r, err := c.EnvironmentsQueryWithResponse(ctxTimeout,
 			&cloudapi.EnvironmentsQueryParams{
 				Name:   lo.Ternary(name != "", &name, nil),
 				Labels: labelsInput,

--- a/src/cmd/environments/update/add-labels.go
+++ b/src/cmd/environments/update/add-labels.go
@@ -20,12 +20,16 @@ var AddLabelsCmd = &cobra.Command{
 	RunE: func(_ *cobra.Command, args []string) error {
 		ctxTimeout, cancel := context.WithTimeout(context.Background(), config.DefaultTimeout)
 		defer cancel()
-		c := cloudclient.NewClientFromToken(viper.GetString(config.OtterizeAPIAddressKey), config.GetAPIToken(ctxTimeout))
+
+		c, err := cloudclient.NewClientFromToken(viper.GetString(config.OtterizeAPIAddressKey), config.GetAPIToken(ctxTimeout))
+		if err != nil {
+			return err
+		}
 
 		id := args[0]
 		labels := viper.GetStringMapString(LabelsKey)
 
-		r, err := c.Client.AddEnvironmentLabelsMutationWithResponse(ctxTimeout,
+		r, err := c.AddEnvironmentLabelsMutationWithResponse(ctxTimeout,
 			cloudapi.AddEnvironmentLabelsMutationJSONRequestBody{
 				Id:     id,
 				Labels: cloudclient.LabelsToLabelInput(labels),

--- a/src/cmd/environments/update/remove-labels.go
+++ b/src/cmd/environments/update/remove-labels.go
@@ -20,12 +20,16 @@ var RemoveLabelsCmd = &cobra.Command{
 	RunE: func(_ *cobra.Command, args []string) error {
 		ctxTimeout, cancel := context.WithTimeout(context.Background(), config.DefaultTimeout)
 		defer cancel()
-		c := cloudclient.NewClientFromToken(viper.GetString(config.OtterizeAPIAddressKey), config.GetAPIToken(ctxTimeout))
+
+		c, err := cloudclient.NewClientFromToken(viper.GetString(config.OtterizeAPIAddressKey), config.GetAPIToken(ctxTimeout))
+		if err != nil {
+			return err
+		}
 
 		id := args[0]
 		labelKeys := viper.GetStringSlice(LabelsKey)
 
-		r, err := c.Client.DeleteEnvironmentLabelsMutationWithResponse(ctxTimeout,
+		r, err := c.DeleteEnvironmentLabelsMutationWithResponse(ctxTimeout,
 			&cloudapi.DeleteEnvironmentLabelsMutationParams{
 				Id:     id,
 				Labels: labelKeys,

--- a/src/cmd/environments/update/update-env.go
+++ b/src/cmd/environments/update/update-env.go
@@ -21,14 +21,17 @@ var UpdateEnvCmd = &cobra.Command{
 		ctxTimeout, cancel := context.WithTimeout(context.Background(), config.DefaultTimeout)
 		defer cancel()
 
-		c := cloudclient.NewClientFromToken(viper.GetString(config.OtterizeAPIAddressKey), config.GetAPIToken(ctxTimeout))
+		c, err := cloudclient.NewClientFromToken(viper.GetString(config.OtterizeAPIAddressKey), config.GetAPIToken(ctxTimeout))
+		if err != nil {
+			return err
+		}
 
 		id := args[0]
 		name := viper.GetString(NameKey)
 		labels := viper.GetStringMapString(LabelsKey)
 		labelsInput := lo.Ternary(len(labels) == 0, nil, lo.ToPtr(cloudclient.LabelsToLabelInput(labels)))
 
-		r, err := c.Client.UpdateEnvironmentMutationWithResponse(ctxTimeout,
+		r, err := c.UpdateEnvironmentMutationWithResponse(ctxTimeout,
 			cloudapi.UpdateEnvironmentMutationJSONRequestBody{
 				Id:     id,
 				Labels: labelsInput,

--- a/src/cmd/integrations/create/create-integration.go
+++ b/src/cmd/integrations/create/create-integration.go
@@ -20,14 +20,17 @@ var CreateIntegrationCmd = &cobra.Command{
 		ctxTimeout, cancel := context.WithTimeout(context.Background(), config.DefaultTimeout)
 		defer cancel()
 
-		c := cloudclient.NewClientFromToken(viper.GetString(config.OtterizeAPIAddressKey), config.GetAPIToken(ctxTimeout))
+		c, err := cloudclient.NewClientFromToken(viper.GetString(config.OtterizeAPIAddressKey), config.GetAPIToken(ctxTimeout))
+		if err != nil {
+			return err
+		}
 
 		name := viper.GetString(NameKey)
 		environmentIDS := viper.GetStringSlice(EnvironmentIDKey)
 		allEnvsAllowed := viper.GetBool(AllEnvsAllowKey)
 		integrationType := viper.GetString(IntegrationTypeKey)
 
-		r, err := c.Client.CreateIntegrationMutationWithResponse(ctxTimeout,
+		r, err := c.CreateIntegrationMutationWithResponse(ctxTimeout,
 			cloudapi.CreateIntegrationMutationJSONRequestBody{
 				Name:            name,
 				IntegrationType: cloudapi.CreateIntegrationMutationJSONBodyIntegrationType(integrationType),

--- a/src/cmd/integrations/delete/delete-integration.go
+++ b/src/cmd/integrations/delete/delete-integration.go
@@ -20,11 +20,14 @@ var DeleteIntegrationCmd = &cobra.Command{
 	RunE: func(_ *cobra.Command, args []string) error {
 		ctxTimeout, cancel := context.WithTimeout(context.Background(), config.DefaultTimeout)
 		defer cancel()
-		c := cloudclient.NewClientFromToken(viper.GetString(config.OtterizeAPIAddressKey), config.GetAPIToken(ctxTimeout))
+		c, err := cloudclient.NewClientFromToken(viper.GetString(config.OtterizeAPIAddressKey), config.GetAPIToken(ctxTimeout))
+		if err != nil {
+			return err
+		}
 
 		id := args[0]
 
-		r, err := c.Client.DeleteIntegrationMutationWithResponse(ctxTimeout, id)
+		r, err := c.DeleteIntegrationMutationWithResponse(ctxTimeout, id)
 		if err != nil {
 			return err
 		}

--- a/src/cmd/integrations/get/get-integration.go
+++ b/src/cmd/integrations/get/get-integration.go
@@ -20,11 +20,14 @@ var GetIntegrationCmd = &cobra.Command{
 	RunE: func(_ *cobra.Command, args []string) error {
 		ctxTimeout, cancel := context.WithTimeout(context.Background(), config.DefaultTimeout)
 		defer cancel()
-		c := cloudclient.NewClientFromToken(viper.GetString(config.OtterizeAPIAddressKey), config.GetAPIToken(ctxTimeout))
+		c, err := cloudclient.NewClientFromToken(viper.GetString(config.OtterizeAPIAddressKey), config.GetAPIToken(ctxTimeout))
+		if err != nil {
+			return err
+		}
 
 		id := args[0]
 
-		r, err := c.Client.IntegrationQueryWithResponse(ctxTimeout, id)
+		r, err := c.IntegrationQueryWithResponse(ctxTimeout, id)
 		if err != nil {
 			return err
 		}

--- a/src/cmd/integrations/list/list-integrations.go
+++ b/src/cmd/integrations/list/list-integrations.go
@@ -20,13 +20,16 @@ var ListIntegrationsCmd = &cobra.Command{
 	RunE: func(_ *cobra.Command, args []string) error {
 		ctxTimeout, cancel := context.WithTimeout(context.Background(), config.DefaultTimeout)
 		defer cancel()
-		c := cloudclient.NewClientFromToken(viper.GetString(config.OtterizeAPIAddressKey), config.GetAPIToken(ctxTimeout))
+		c, err := cloudclient.NewClientFromToken(viper.GetString(config.OtterizeAPIAddressKey), config.GetAPIToken(ctxTimeout))
+		if err != nil {
+			return err
+		}
 
 		envId := viper.GetString(EnvironmentIDKey)
 		name := viper.GetString(NameKey)
 		integrationType := viper.GetString(IntegrationTypeKey)
 
-		r, err := c.Client.IntegrationsQueryWithResponse(ctxTimeout,
+		r, err := c.IntegrationsQueryWithResponse(ctxTimeout,
 			&cloudapi.IntegrationsQueryParams{
 				Name:            lo.Ternary(name != "", &name, nil),
 				IntegrationType: lo.Ternary(integrationType != "", lo.ToPtr(cloudapi.IntegrationsQueryParamsIntegrationType(integrationType)), nil),

--- a/src/cmd/integrations/update/update-integration.go
+++ b/src/cmd/integrations/update/update-integration.go
@@ -20,12 +20,15 @@ var UpdateIntegrationlicationCmd = &cobra.Command{
 	RunE: func(_ *cobra.Command, args []string) error {
 		ctxTimeout, cancel := context.WithTimeout(context.Background(), config.DefaultTimeout)
 		defer cancel()
-		c := cloudclient.NewClientFromToken(viper.GetString(config.OtterizeAPIAddressKey), config.GetAPIToken(ctxTimeout))
+		c, err := cloudclient.NewClientFromToken(viper.GetString(config.OtterizeAPIAddressKey), config.GetAPIToken(ctxTimeout))
+		if err != nil {
+			return err
+		}
 
 		id := args[0]
 		name := viper.GetString(NameKey)
 
-		r, err := c.Client.UpdateIntegrationMutationWithResponse(ctxTimeout,
+		r, err := c.UpdateIntegrationMutationWithResponse(ctxTimeout,
 			cloudapi.UpdateIntegrationMutationJSONRequestBody{
 				Id:   id,
 				Name: lo.Ternary(name != "", &name, nil),

--- a/src/cmd/invites/accept/accept-invite.go
+++ b/src/cmd/invites/accept/accept-invite.go
@@ -21,11 +21,14 @@ var AcceptInviteCmd = &cobra.Command{
 		ctxTimeout, cancel := context.WithTimeout(context.Background(), config.DefaultTimeout)
 		defer cancel()
 
-		c := cloudclient.NewClientFromToken(viper.GetString(config.OtterizeAPIAddressKey), config.GetAPIToken(ctxTimeout))
+		c, err := cloudclient.NewClientFromToken(viper.GetString(config.OtterizeAPIAddressKey), config.GetAPIToken(ctxTimeout))
+		if err != nil {
+			return err
+		}
 
 		inviteID := args[0]
 
-		acceptResponse, err := c.Client.AcceptInviteMutationWithResponse(ctxTimeout,
+		acceptResponse, err := c.AcceptInviteMutationWithResponse(ctxTimeout,
 			cloudapi.AcceptInviteMutationJSONRequestBody{
 				Id: inviteID,
 			},
@@ -39,7 +42,7 @@ var AcceptInviteCmd = &cobra.Command{
 			return output.FormatHTTPError(acceptResponse)
 		}
 
-		userResponse, err := c.Client.MeQueryWithResponse(ctxTimeout)
+		userResponse, err := c.MeQueryWithResponse(ctxTimeout)
 		if err != nil {
 			return err
 		}

--- a/src/cmd/invites/create/create-invite.go
+++ b/src/cmd/invites/create/create-invite.go
@@ -20,11 +20,14 @@ var CreateInviteCmd = &cobra.Command{
 		ctxTimeout, cancel := context.WithTimeout(context.Background(), config.DefaultTimeout)
 		defer cancel()
 
-		c := cloudclient.NewClientFromToken(viper.GetString(config.OtterizeAPIAddressKey), config.GetAPIToken(ctxTimeout))
+		c, err := cloudclient.NewClientFromToken(viper.GetString(config.OtterizeAPIAddressKey), config.GetAPIToken(ctxTimeout))
+		if err != nil {
+			return err
+		}
 
 		email := viper.GetString(EmailKey)
 
-		r, err := c.Client.CreateInviteMutationWithResponse(ctxTimeout,
+		r, err := c.CreateInviteMutationWithResponse(ctxTimeout,
 			cloudapi.CreateInviteMutationJSONRequestBody{Email: email},
 		)
 		if err != nil {

--- a/src/cmd/invites/delete/delete-invite.go
+++ b/src/cmd/invites/delete/delete-invite.go
@@ -21,11 +21,14 @@ var DeleteInviteCmd = &cobra.Command{
 	RunE: func(_ *cobra.Command, args []string) error {
 		ctxTimeout, cancel := context.WithTimeout(context.Background(), config.DefaultTimeout)
 		defer cancel()
-		c := cloudclient.NewClientFromToken(viper.GetString(config.OtterizeAPIAddressKey), config.GetAPIToken(ctxTimeout))
+		c, err := cloudclient.NewClientFromToken(viper.GetString(config.OtterizeAPIAddressKey), config.GetAPIToken(ctxTimeout))
+		if err != nil {
+			return err
+		}
 
 		id := args[0]
 
-		r, err := c.Client.DeleteInviteMutationWithResponse(ctxTimeout, id)
+		r, err := c.DeleteInviteMutationWithResponse(ctxTimeout, id)
 		if err != nil {
 			return err
 		}

--- a/src/cmd/invites/list/list-invites.go
+++ b/src/cmd/invites/list/list-invites.go
@@ -20,9 +20,12 @@ var ListInvitesCmd = &cobra.Command{
 		ctxTimeout, cancel := context.WithTimeout(context.Background(), config.DefaultTimeout)
 		defer cancel()
 
-		c := cloudclient.NewClientFromToken(viper.GetString(config.OtterizeAPIAddressKey), config.GetAPIToken(ctxTimeout))
+		c, err := cloudclient.NewClientFromToken(viper.GetString(config.OtterizeAPIAddressKey), config.GetAPIToken(ctxTimeout))
+		if err != nil {
+			return err
+		}
 
-		r, err := c.Client.InvitesQueryWithResponse(ctxTimeout, &cloudapi.InvitesQueryParams{})
+		r, err := c.InvitesQueryWithResponse(ctxTimeout, &cloudapi.InvitesQueryParams{})
 		if err != nil {
 			return err
 		}

--- a/src/cmd/login/login.go
+++ b/src/cmd/login/login.go
@@ -52,8 +52,11 @@ func login(_ *cobra.Command, _ []string) error {
 	defer cancel()
 
 	apiAddress := viper.GetString(config.OtterizeAPIAddressKey)
-	c := cloudclient.NewClientFromToken(apiAddress, authResult.AccessToken)
-	meResponse, err := c.Client.MeQueryWithResponse(registerCtxTimeout)
+	c, err := cloudclient.NewClientFromToken(apiAddress, authResult.AccessToken)
+	if err != nil {
+		return err
+	}
+	meResponse, err := c.MeQueryWithResponse(registerCtxTimeout)
 	if err != nil {
 		return err
 	}
@@ -76,7 +79,7 @@ func login(_ *cobra.Command, _ []string) error {
 	}
 
 	// query user to get full user info
-	userResponse, err := c.Client.UserQueryWithResponse(registerCtxTimeout, userId)
+	userResponse, err := c.UserQueryWithResponse(registerCtxTimeout, userId)
 	if err != nil {
 		return err
 	}

--- a/src/cmd/organizations/create/create-organization.go
+++ b/src/cmd/organizations/create/create-organization.go
@@ -19,9 +19,12 @@ var CreateOrganizationCmd = &cobra.Command{
 	RunE: func(_ *cobra.Command, args []string) error {
 		ctxTimeout, cancel := context.WithTimeout(context.Background(), config.DefaultTimeout)
 		defer cancel()
-		c := cloudclient.NewClientFromToken(viper.GetString(config.OtterizeAPIAddressKey), config.GetAPIToken(ctxTimeout))
+		c, err := cloudclient.NewClientFromToken(viper.GetString(config.OtterizeAPIAddressKey), config.GetAPIToken(ctxTimeout))
+		if err != nil {
+			return err
+		}
 
-		r, err := c.Client.CreateOrganizationMutationWithResponse(ctxTimeout,
+		r, err := c.CreateOrganizationMutationWithResponse(ctxTimeout,
 			cloudapi.CreateOrganizationMutationJSONRequestBody{},
 		)
 		if err != nil {

--- a/src/cmd/organizations/get/get-organization.go
+++ b/src/cmd/organizations/get/get-organization.go
@@ -21,11 +21,14 @@ var GetOrganizationCmd = &cobra.Command{
 	RunE: func(_ *cobra.Command, args []string) error {
 		ctxTimeout, cancel := context.WithTimeout(context.Background(), config.DefaultTimeout)
 		defer cancel()
-		c := cloudclient.NewClientFromToken(viper.GetString(config.OtterizeAPIAddressKey), config.GetAPIToken(ctxTimeout))
+		c, err := cloudclient.NewClientFromToken(viper.GetString(config.OtterizeAPIAddressKey), config.GetAPIToken(ctxTimeout))
+		if err != nil {
+			return err
+		}
 
 		id := args[0]
 
-		r, err := c.Client.OrganizationQueryWithResponse(ctxTimeout, id)
+		r, err := c.OrganizationQueryWithResponse(ctxTimeout, id)
 		if err != nil {
 			return err
 		}

--- a/src/cmd/organizations/list/list-organizations.go
+++ b/src/cmd/organizations/list/list-organizations.go
@@ -19,9 +19,12 @@ var ListOrganizationsCmd = &cobra.Command{
 	RunE: func(_ *cobra.Command, args []string) error {
 		ctxTimeout, cancel := context.WithTimeout(context.Background(), config.DefaultTimeout)
 		defer cancel()
-		c := cloudclient.NewClientFromToken(viper.GetString(config.OtterizeAPIAddressKey), config.GetAPIToken(ctxTimeout))
+		c, err := cloudclient.NewClientFromToken(viper.GetString(config.OtterizeAPIAddressKey), config.GetAPIToken(ctxTimeout))
+		if err != nil {
+			return err
+		}
 
-		r, err := c.Client.OrganizationsQueryWithResponse(ctxTimeout)
+		r, err := c.OrganizationsQueryWithResponse(ctxTimeout)
 		if err != nil {
 			return err
 		}

--- a/src/cmd/organizations/update/update-organization.go
+++ b/src/cmd/organizations/update/update-organization.go
@@ -21,12 +21,15 @@ var UpdateOrganizationCmd = &cobra.Command{
 	RunE: func(_ *cobra.Command, args []string) error {
 		ctxTimeout, cancel := context.WithTimeout(context.Background(), config.DefaultTimeout)
 		defer cancel()
-		c := cloudclient.NewClientFromToken(viper.GetString(config.OtterizeAPIAddressKey), config.GetAPIToken(ctxTimeout))
+		c, err := cloudclient.NewClientFromToken(viper.GetString(config.OtterizeAPIAddressKey), config.GetAPIToken(ctxTimeout))
+		if err != nil {
+			return err
+		}
 
 		id := args[0]
 		name := viper.GetString(NameKey)
 
-		r, err := c.Client.UpdateOrganizationMutationWithResponse(ctxTimeout,
+		r, err := c.UpdateOrganizationMutationWithResponse(ctxTimeout,
 			cloudapi.UpdateOrganizationMutationJSONRequestBody{
 				Id:   id,
 				Name: lo.Ternary(name != "", &name, nil),

--- a/src/cmd/users/create/create-user.go
+++ b/src/cmd/users/create/create-user.go
@@ -20,12 +20,15 @@ var CreateUserCmd = &cobra.Command{
 		ctxTimeout, cancel := context.WithTimeout(context.Background(), config.DefaultTimeout)
 		defer cancel()
 
-		c := cloudclient.NewClientFromToken(viper.GetString(config.OtterizeAPIAddressKey), config.GetAPIToken(ctxTimeout))
+		c, err := cloudclient.NewClientFromToken(viper.GetString(config.OtterizeAPIAddressKey), config.GetAPIToken(ctxTimeout))
+		if err != nil {
+			return err
+		}
 
 		email := viper.GetString(EmailKey)
 		authProviderUserId := viper.GetString(AuthProviderUserId)
 
-		r, err := c.Client.CreateUserMutationWithResponse(ctxTimeout,
+		r, err := c.CreateUserMutationWithResponse(ctxTimeout,
 			cloudapi.CreateUserMutationJSONRequestBody{
 				AuthProviderUserId: authProviderUserId,
 				Email:              email,

--- a/src/cmd/users/delete/delete-user.go
+++ b/src/cmd/users/delete/delete-user.go
@@ -20,11 +20,14 @@ var DeleteUserCmd = &cobra.Command{
 	RunE: func(_ *cobra.Command, args []string) error {
 		ctxTimeout, cancel := context.WithTimeout(context.Background(), config.DefaultTimeout)
 		defer cancel()
-		c := cloudclient.NewClientFromToken(viper.GetString(config.OtterizeAPIAddressKey), config.GetAPIToken(ctxTimeout))
+		c, err := cloudclient.NewClientFromToken(viper.GetString(config.OtterizeAPIAddressKey), config.GetAPIToken(ctxTimeout))
+		if err != nil {
+			return err
+		}
 
 		id := args[0]
 
-		r, err := c.Client.DeleteUserMutationWithResponse(ctxTimeout, id)
+		r, err := c.DeleteUserMutationWithResponse(ctxTimeout, id)
 		if err != nil {
 			return err
 		}

--- a/src/cmd/users/get/get-user.go
+++ b/src/cmd/users/get/get-user.go
@@ -20,10 +20,13 @@ var GetUserCmd = &cobra.Command{
 	RunE: func(_ *cobra.Command, args []string) error {
 		ctxTimeout, cancel := context.WithTimeout(context.Background(), config.DefaultTimeout)
 		defer cancel()
-		c := cloudclient.NewClientFromToken(viper.GetString(config.OtterizeAPIAddressKey), config.GetAPIToken(ctxTimeout))
+		c, err := cloudclient.NewClientFromToken(viper.GetString(config.OtterizeAPIAddressKey), config.GetAPIToken(ctxTimeout))
+		if err != nil {
+			return err
+		}
 
 		id := args[0]
-		r, err := c.Client.UserQueryWithResponse(ctxTimeout, id)
+		r, err := c.UserQueryWithResponse(ctxTimeout, id)
 		if err != nil {
 			return err
 		}

--- a/src/cmd/users/list/list-users.go
+++ b/src/cmd/users/list/list-users.go
@@ -19,9 +19,12 @@ var ListUsersCmd = &cobra.Command{
 	RunE: func(_ *cobra.Command, args []string) error {
 		ctxTimeout, cancel := context.WithTimeout(context.Background(), config.DefaultTimeout)
 		defer cancel()
-		c := cloudclient.NewClientFromToken(viper.GetString(config.OtterizeAPIAddressKey), config.GetAPIToken(ctxTimeout))
+		c, err := cloudclient.NewClientFromToken(viper.GetString(config.OtterizeAPIAddressKey), config.GetAPIToken(ctxTimeout))
+		if err != nil {
+			return err
+		}
 
-		r, err := c.Client.UsersQueryWithResponse(ctxTimeout)
+		r, err := c.UsersQueryWithResponse(ctxTimeout)
 		if err != nil {
 			return err
 		}

--- a/src/pkg/cloudclient/restapi/client.go
+++ b/src/pkg/cloudclient/restapi/client.go
@@ -1,39 +1,18 @@
 package restapi
 
 import (
-	"context"
+	"github.com/deepmap/oapi-codegen/pkg/securityprovider"
 	"github.com/otterize/otterize-cli/src/pkg/cloudclient/restapi/cloudapi"
-	"golang.org/x/oauth2"
 )
 
-func withAuth(tokenSrc oauth2.TokenSource) func(client *cloudapi.Client) error {
-	return func(client *cloudapi.Client) error {
-		client.Client = oauth2.NewClient(context.Background(), tokenSrc)
-		return nil
-	}
-}
-
-type Client struct {
-	Address string
-	Client  *cloudapi.ClientWithResponses
-}
-
-func NewClientFromToken(address string, token string) *Client {
-	oauth2Token := &oauth2.Token{AccessToken: token}
-	return NewClient(address, oauth2.StaticTokenSource(oauth2Token))
-}
-
-func NewClient(address string, tokenSrc oauth2.TokenSource) *Client {
+func NewClientFromToken(address string, token string) (*cloudapi.ClientWithResponses, error) {
 	address = address + "/rest/v1"
-	c, err := cloudapi.NewClientWithResponses(address, withAuth(tokenSrc))
+	bearerTokenProvider, err := securityprovider.NewSecurityProviderBearerToken(token)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
-	return &Client{
-		Address: address,
-		Client:  c,
-	}
+	return cloudapi.NewClientWithResponses(address, cloudapi.WithRequestEditorFn(bearerTokenProvider.Intercept))
 }
 
 func IsErrorStatus(statusCode int) bool {

--- a/src/pkg/cloudclient/restapi/cloudapi/api.gen.go
+++ b/src/pkg/cloudclient/restapi/cloudapi/api.gen.go
@@ -17,6 +17,10 @@ import (
 	"github.com/deepmap/oapi-codegen/pkg/runtime"
 )
 
+const (
+	BearerAuthScopes = "bearerAuth.Scopes"
+)
+
 // Defines values for HTTPConfigMethod.
 const (
 	CONNECT HTTPConfigMethod = "CONNECT"

--- a/src/pkg/cloudclient/restapi/cloudapi/api.gen.go
+++ b/src/pkg/cloudclient/restapi/cloudapi/api.gen.go
@@ -59,6 +59,14 @@ const (
 	Produce         KafkaConfigOperation = "produce"
 )
 
+// Defines values for OneIntegrationQueryParamsIntegrationType.
+const (
+	OneIntegrationQueryParamsIntegrationTypeCICD       OneIntegrationQueryParamsIntegrationType = "CICD"
+	OneIntegrationQueryParamsIntegrationTypeKafka      OneIntegrationQueryParamsIntegrationType = "Kafka"
+	OneIntegrationQueryParamsIntegrationTypeKubernetes OneIntegrationQueryParamsIntegrationType = "Kubernetes"
+	OneIntegrationQueryParamsIntegrationTypeService    OneIntegrationQueryParamsIntegrationType = "Service"
+)
+
 // Defines values for IntegrationsQueryParamsIntegrationType.
 const (
 	IntegrationsQueryParamsIntegrationTypeCICD       IntegrationsQueryParamsIntegrationType = "CICD"
@@ -73,14 +81,6 @@ const (
 	CreateIntegrationMutationJSONBodyIntegrationTypeKafka      CreateIntegrationMutationJSONBodyIntegrationType = "Kafka"
 	CreateIntegrationMutationJSONBodyIntegrationTypeKubernetes CreateIntegrationMutationJSONBodyIntegrationType = "Kubernetes"
 	CreateIntegrationMutationJSONBodyIntegrationTypeService    CreateIntegrationMutationJSONBodyIntegrationType = "Service"
-)
-
-// Defines values for OneIntegrationQueryParamsIntegrationType.
-const (
-	OneIntegrationQueryParamsIntegrationTypeCICD       OneIntegrationQueryParamsIntegrationType = "CICD"
-	OneIntegrationQueryParamsIntegrationTypeKafka      OneIntegrationQueryParamsIntegrationType = "Kafka"
-	OneIntegrationQueryParamsIntegrationTypeKubernetes OneIntegrationQueryParamsIntegrationType = "Kubernetes"
-	OneIntegrationQueryParamsIntegrationTypeService    OneIntegrationQueryParamsIntegrationType = "Service"
 )
 
 // Defines values for InvitesQueryParamsStatus.
@@ -255,6 +255,11 @@ type User struct {
 	Organization         *Organization        `json:"organization,omitempty"`
 }
 
+// OneEnvironmentQueryParams defines parameters for OneEnvironmentQuery.
+type OneEnvironmentQueryParams struct {
+	Name string `form:"name" json:"name"`
+}
+
 // EnvironmentsQueryParams defines parameters for EnvironmentsQuery.
 type EnvironmentsQueryParams struct {
 	Name   *string       `form:"name,omitempty" json:"name,omitempty"`
@@ -286,15 +291,20 @@ type AddEnvironmentLabelsMutationJSONBody struct {
 	Labels []LabelInput `json:"labels"`
 }
 
-// OneEnvironmentQueryParams defines parameters for OneEnvironmentQuery.
-type OneEnvironmentQueryParams struct {
-	Name string `form:"name" json:"name"`
-}
-
 // DeleteEnvironmentMutationParams defines parameters for DeleteEnvironmentMutation.
 type DeleteEnvironmentMutationParams struct {
 	Force *bool `form:"force,omitempty" json:"force,omitempty"`
 }
+
+// OneIntegrationQueryParams defines parameters for OneIntegrationQuery.
+type OneIntegrationQueryParams struct {
+	Name            *string                                   `form:"name,omitempty" json:"name,omitempty"`
+	IntegrationType *OneIntegrationQueryParamsIntegrationType `form:"integrationType,omitempty" json:"integrationType,omitempty"`
+	EnvironmentId   *string                                   `form:"environmentId,omitempty" json:"environmentId,omitempty"`
+}
+
+// OneIntegrationQueryParamsIntegrationType defines parameters for OneIntegrationQuery.
+type OneIntegrationQueryParamsIntegrationType string
 
 // IntegrationsQueryParams defines parameters for IntegrationsQuery.
 type IntegrationsQueryParams struct {
@@ -321,16 +331,6 @@ type CreateIntegrationMutationJSONBody struct {
 
 // CreateIntegrationMutationJSONBodyIntegrationType defines parameters for CreateIntegrationMutation.
 type CreateIntegrationMutationJSONBodyIntegrationType string
-
-// OneIntegrationQueryParams defines parameters for OneIntegrationQuery.
-type OneIntegrationQueryParams struct {
-	Name            *string                                   `form:"name,omitempty" json:"name,omitempty"`
-	IntegrationType *OneIntegrationQueryParamsIntegrationType `form:"integrationType,omitempty" json:"integrationType,omitempty"`
-	EnvironmentId   *string                                   `form:"environmentId,omitempty" json:"environmentId,omitempty"`
-}
-
-// OneIntegrationQueryParamsIntegrationType defines parameters for OneIntegrationQuery.
-type OneIntegrationQueryParamsIntegrationType string
 
 // IntentsQueryParams defines parameters for IntentsQuery.
 type IntentsQueryParams struct {
@@ -368,16 +368,16 @@ type UpdateOrganizationMutationJSONBody struct {
 // CreateOrganizationMutationJSONBody defines parameters for CreateOrganizationMutation.
 type CreateOrganizationMutationJSONBody = map[string]interface{}
 
-// ServicesQueryParams defines parameters for ServicesQuery.
-type ServicesQueryParams struct {
-	EnvironmentId *string `form:"environmentId,omitempty" json:"environmentId,omitempty"`
-	Name          *string `form:"name,omitempty" json:"name,omitempty"`
-}
-
 // OneServiceQueryParams defines parameters for OneServiceQuery.
 type OneServiceQueryParams struct {
 	EnvironmentId string `form:"environmentId" json:"environmentId"`
 	Name          string `form:"name" json:"name"`
+}
+
+// ServicesQueryParams defines parameters for ServicesQuery.
+type ServicesQueryParams struct {
+	EnvironmentId *string `form:"environmentId,omitempty" json:"environmentId,omitempty"`
+	Name          *string `form:"name,omitempty" json:"name,omitempty"`
 }
 
 // CreateUserMutationJSONBody defines parameters for CreateUserMutation.
@@ -489,6 +489,9 @@ func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
 
 // The interface specification for the client above.
 type ClientInterface interface {
+	// OneEnvironmentQuery request
+	OneEnvironmentQuery(ctx context.Context, params *OneEnvironmentQueryParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
 	// EnvironmentsQuery request
 	EnvironmentsQuery(ctx context.Context, params *EnvironmentsQueryParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
@@ -510,14 +513,14 @@ type ClientInterface interface {
 
 	AddEnvironmentLabelsMutation(ctx context.Context, body AddEnvironmentLabelsMutationJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// OneEnvironmentQuery request
-	OneEnvironmentQuery(ctx context.Context, params *OneEnvironmentQueryParams, reqEditors ...RequestEditorFn) (*http.Response, error)
-
 	// DeleteEnvironmentMutation request
 	DeleteEnvironmentMutation(ctx context.Context, id string, params *DeleteEnvironmentMutationParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// EnvironmentQuery request
 	EnvironmentQuery(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// OneIntegrationQuery request
+	OneIntegrationQuery(ctx context.Context, params *OneIntegrationQueryParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// IntegrationsQuery request
 	IntegrationsQuery(ctx context.Context, params *IntegrationsQueryParams, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -531,9 +534,6 @@ type ClientInterface interface {
 	CreateIntegrationMutationWithBody(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	CreateIntegrationMutation(ctx context.Context, body CreateIntegrationMutationJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
-
-	// OneIntegrationQuery request
-	OneIntegrationQuery(ctx context.Context, params *OneIntegrationQueryParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// DeleteIntegrationMutation request
 	DeleteIntegrationMutation(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -585,11 +585,11 @@ type ClientInterface interface {
 	// OrganizationQuery request
 	OrganizationQuery(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// ServicesQuery request
-	ServicesQuery(ctx context.Context, params *ServicesQueryParams, reqEditors ...RequestEditorFn) (*http.Response, error)
-
 	// OneServiceQuery request
 	OneServiceQuery(ctx context.Context, params *OneServiceQueryParams, reqEditors ...RequestEditorFn) (*http.Response, error)
+
+	// ServicesQuery request
+	ServicesQuery(ctx context.Context, params *ServicesQueryParams, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ServiceQuery request
 	ServiceQuery(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -607,6 +607,18 @@ type ClientInterface interface {
 
 	// UserQuery request
 	UserQuery(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error)
+}
+
+func (c *Client) OneEnvironmentQuery(ctx context.Context, params *OneEnvironmentQueryParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewOneEnvironmentQueryRequest(c.Server, params)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
 }
 
 func (c *Client) EnvironmentsQuery(ctx context.Context, params *EnvironmentsQueryParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
@@ -705,18 +717,6 @@ func (c *Client) AddEnvironmentLabelsMutation(ctx context.Context, body AddEnvir
 	return c.Client.Do(req)
 }
 
-func (c *Client) OneEnvironmentQuery(ctx context.Context, params *OneEnvironmentQueryParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewOneEnvironmentQueryRequest(c.Server, params)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
 func (c *Client) DeleteEnvironmentMutation(ctx context.Context, id string, params *DeleteEnvironmentMutationParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewDeleteEnvironmentMutationRequest(c.Server, id, params)
 	if err != nil {
@@ -731,6 +731,18 @@ func (c *Client) DeleteEnvironmentMutation(ctx context.Context, id string, param
 
 func (c *Client) EnvironmentQuery(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewEnvironmentQueryRequest(c.Server, id)
+	if err != nil {
+		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
+		return nil, err
+	}
+	return c.Client.Do(req)
+}
+
+func (c *Client) OneIntegrationQuery(ctx context.Context, params *OneIntegrationQueryParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewOneIntegrationQueryRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -791,18 +803,6 @@ func (c *Client) CreateIntegrationMutationWithBody(ctx context.Context, contentT
 
 func (c *Client) CreateIntegrationMutation(ctx context.Context, body CreateIntegrationMutationJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
 	req, err := NewCreateIntegrationMutationRequest(c.Server, body)
-	if err != nil {
-		return nil, err
-	}
-	req = req.WithContext(ctx)
-	if err := c.applyEditors(ctx, req, reqEditors); err != nil {
-		return nil, err
-	}
-	return c.Client.Do(req)
-}
-
-func (c *Client) OneIntegrationQuery(ctx context.Context, params *OneIntegrationQueryParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewOneIntegrationQueryRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -1029,8 +1029,8 @@ func (c *Client) OrganizationQuery(ctx context.Context, id string, reqEditors ..
 	return c.Client.Do(req)
 }
 
-func (c *Client) ServicesQuery(ctx context.Context, params *ServicesQueryParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewServicesQueryRequest(c.Server, params)
+func (c *Client) OneServiceQuery(ctx context.Context, params *OneServiceQueryParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewOneServiceQueryRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -1041,8 +1041,8 @@ func (c *Client) ServicesQuery(ctx context.Context, params *ServicesQueryParams,
 	return c.Client.Do(req)
 }
 
-func (c *Client) OneServiceQuery(ctx context.Context, params *OneServiceQueryParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewOneServiceQueryRequest(c.Server, params)
+func (c *Client) ServicesQuery(ctx context.Context, params *ServicesQueryParams, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewServicesQueryRequest(c.Server, params)
 	if err != nil {
 		return nil, err
 	}
@@ -1123,6 +1123,49 @@ func (c *Client) UserQuery(ctx context.Context, id string, reqEditors ...Request
 		return nil, err
 	}
 	return c.Client.Do(req)
+}
+
+// NewOneEnvironmentQueryRequest generates requests for OneEnvironmentQuery
+func NewOneEnvironmentQueryRequest(server string, params *OneEnvironmentQueryParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/environment")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	queryValues := queryURL.Query()
+
+	if queryFrag, err := runtime.StyleParamWithLocation("form", true, "name", runtime.ParamLocationQuery, params.Name); err != nil {
+		return nil, err
+	} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+		return nil, err
+	} else {
+		for k, v := range parsed {
+			for _, v2 := range v {
+				queryValues.Add(k, v2)
+			}
+		}
+	}
+
+	queryURL.RawQuery = queryValues.Encode()
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
 }
 
 // NewEnvironmentsQueryRequest generates requests for EnvironmentsQuery
@@ -1363,49 +1406,6 @@ func NewAddEnvironmentLabelsMutationRequestWithBody(server string, contentType s
 	return req, nil
 }
 
-// NewOneEnvironmentQueryRequest generates requests for OneEnvironmentQuery
-func NewOneEnvironmentQueryRequest(server string, params *OneEnvironmentQueryParams) (*http.Request, error) {
-	var err error
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/environments/one")
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	queryValues := queryURL.Query()
-
-	if queryFrag, err := runtime.StyleParamWithLocation("form", true, "name", runtime.ParamLocationQuery, params.Name); err != nil {
-		return nil, err
-	} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-		return nil, err
-	} else {
-		for k, v := range parsed {
-			for _, v2 := range v {
-				queryValues.Add(k, v2)
-			}
-		}
-	}
-
-	queryURL.RawQuery = queryValues.Encode()
-
-	req, err := http.NewRequest("GET", queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return req, nil
-}
-
 // NewDeleteEnvironmentMutationRequest generates requests for DeleteEnvironmentMutation
 func NewDeleteEnvironmentMutationRequest(server string, id string, params *DeleteEnvironmentMutationParams) (*http.Request, error) {
 	var err error
@@ -1485,6 +1485,85 @@ func NewEnvironmentQueryRequest(server string, id string) (*http.Request, error)
 	if err != nil {
 		return nil, err
 	}
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewOneIntegrationQueryRequest generates requests for OneIntegrationQuery
+func NewOneIntegrationQueryRequest(server string, params *OneIntegrationQueryParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/integration")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	queryValues := queryURL.Query()
+
+	if params.Name != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "name", runtime.ParamLocationQuery, *params.Name); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.IntegrationType != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "integrationType", runtime.ParamLocationQuery, *params.IntegrationType); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.EnvironmentId != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "environmentId", runtime.ParamLocationQuery, *params.EnvironmentId); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	queryURL.RawQuery = queryValues.Encode()
 
 	req, err := http.NewRequest("GET", queryURL.String(), nil)
 	if err != nil {
@@ -1649,85 +1728,6 @@ func NewCreateIntegrationMutationRequestWithBody(server string, contentType stri
 	}
 
 	req.Header.Add("Content-Type", contentType)
-
-	return req, nil
-}
-
-// NewOneIntegrationQueryRequest generates requests for OneIntegrationQuery
-func NewOneIntegrationQueryRequest(server string, params *OneIntegrationQueryParams) (*http.Request, error) {
-	var err error
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/integrations/one")
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	queryValues := queryURL.Query()
-
-	if params.Name != nil {
-
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "name", runtime.ParamLocationQuery, *params.Name); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
-				}
-			}
-		}
-
-	}
-
-	if params.IntegrationType != nil {
-
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "integrationType", runtime.ParamLocationQuery, *params.IntegrationType); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
-				}
-			}
-		}
-
-	}
-
-	if params.EnvironmentId != nil {
-
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "environmentId", runtime.ParamLocationQuery, *params.EnvironmentId); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
-				}
-			}
-		}
-
-	}
-
-	queryURL.RawQuery = queryValues.Encode()
-
-	req, err := http.NewRequest("GET", queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
 
 	return req, nil
 }
@@ -2292,6 +2292,61 @@ func NewOrganizationQueryRequest(server string, id string) (*http.Request, error
 	return req, nil
 }
 
+// NewOneServiceQueryRequest generates requests for OneServiceQuery
+func NewOneServiceQueryRequest(server string, params *OneServiceQueryParams) (*http.Request, error) {
+	var err error
+
+	serverURL, err := url.Parse(server)
+	if err != nil {
+		return nil, err
+	}
+
+	operationPath := fmt.Sprintf("/service")
+	if operationPath[0] == '/' {
+		operationPath = "." + operationPath
+	}
+
+	queryURL, err := serverURL.Parse(operationPath)
+	if err != nil {
+		return nil, err
+	}
+
+	queryValues := queryURL.Query()
+
+	if queryFrag, err := runtime.StyleParamWithLocation("form", true, "environmentId", runtime.ParamLocationQuery, params.EnvironmentId); err != nil {
+		return nil, err
+	} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+		return nil, err
+	} else {
+		for k, v := range parsed {
+			for _, v2 := range v {
+				queryValues.Add(k, v2)
+			}
+		}
+	}
+
+	if queryFrag, err := runtime.StyleParamWithLocation("form", true, "name", runtime.ParamLocationQuery, params.Name); err != nil {
+		return nil, err
+	} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+		return nil, err
+	} else {
+		for k, v := range parsed {
+			for _, v2 := range v {
+				queryValues.Add(k, v2)
+			}
+		}
+	}
+
+	queryURL.RawQuery = queryValues.Encode()
+
+	req, err := http.NewRequest("GET", queryURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
 // NewServicesQueryRequest generates requests for ServicesQuery
 func NewServicesQueryRequest(server string, params *ServicesQueryParams) (*http.Request, error) {
 	var err error
@@ -2343,61 +2398,6 @@ func NewServicesQueryRequest(server string, params *ServicesQueryParams) (*http.
 			}
 		}
 
-	}
-
-	queryURL.RawQuery = queryValues.Encode()
-
-	req, err := http.NewRequest("GET", queryURL.String(), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	return req, nil
-}
-
-// NewOneServiceQueryRequest generates requests for OneServiceQuery
-func NewOneServiceQueryRequest(server string, params *OneServiceQueryParams) (*http.Request, error) {
-	var err error
-
-	serverURL, err := url.Parse(server)
-	if err != nil {
-		return nil, err
-	}
-
-	operationPath := fmt.Sprintf("/services/one")
-	if operationPath[0] == '/' {
-		operationPath = "." + operationPath
-	}
-
-	queryURL, err := serverURL.Parse(operationPath)
-	if err != nil {
-		return nil, err
-	}
-
-	queryValues := queryURL.Query()
-
-	if queryFrag, err := runtime.StyleParamWithLocation("form", true, "environmentId", runtime.ParamLocationQuery, params.EnvironmentId); err != nil {
-		return nil, err
-	} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-		return nil, err
-	} else {
-		for k, v := range parsed {
-			for _, v2 := range v {
-				queryValues.Add(k, v2)
-			}
-		}
-	}
-
-	if queryFrag, err := runtime.StyleParamWithLocation("form", true, "name", runtime.ParamLocationQuery, params.Name); err != nil {
-		return nil, err
-	} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-		return nil, err
-	} else {
-		for k, v := range parsed {
-			for _, v2 := range v {
-				queryValues.Add(k, v2)
-			}
-		}
 	}
 
 	queryURL.RawQuery = queryValues.Encode()
@@ -2622,6 +2622,9 @@ func WithBaseURL(baseURL string) ClientOption {
 
 // ClientWithResponsesInterface is the interface specification for the client with responses above.
 type ClientWithResponsesInterface interface {
+	// OneEnvironmentQuery request
+	OneEnvironmentQueryWithResponse(ctx context.Context, params *OneEnvironmentQueryParams, reqEditors ...RequestEditorFn) (*OneEnvironmentQueryResponse, error)
+
 	// EnvironmentsQuery request
 	EnvironmentsQueryWithResponse(ctx context.Context, params *EnvironmentsQueryParams, reqEditors ...RequestEditorFn) (*EnvironmentsQueryResponse, error)
 
@@ -2643,14 +2646,14 @@ type ClientWithResponsesInterface interface {
 
 	AddEnvironmentLabelsMutationWithResponse(ctx context.Context, body AddEnvironmentLabelsMutationJSONRequestBody, reqEditors ...RequestEditorFn) (*AddEnvironmentLabelsMutationResponse, error)
 
-	// OneEnvironmentQuery request
-	OneEnvironmentQueryWithResponse(ctx context.Context, params *OneEnvironmentQueryParams, reqEditors ...RequestEditorFn) (*OneEnvironmentQueryResponse, error)
-
 	// DeleteEnvironmentMutation request
 	DeleteEnvironmentMutationWithResponse(ctx context.Context, id string, params *DeleteEnvironmentMutationParams, reqEditors ...RequestEditorFn) (*DeleteEnvironmentMutationResponse, error)
 
 	// EnvironmentQuery request
 	EnvironmentQueryWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*EnvironmentQueryResponse, error)
+
+	// OneIntegrationQuery request
+	OneIntegrationQueryWithResponse(ctx context.Context, params *OneIntegrationQueryParams, reqEditors ...RequestEditorFn) (*OneIntegrationQueryResponse, error)
 
 	// IntegrationsQuery request
 	IntegrationsQueryWithResponse(ctx context.Context, params *IntegrationsQueryParams, reqEditors ...RequestEditorFn) (*IntegrationsQueryResponse, error)
@@ -2664,9 +2667,6 @@ type ClientWithResponsesInterface interface {
 	CreateIntegrationMutationWithBodyWithResponse(ctx context.Context, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*CreateIntegrationMutationResponse, error)
 
 	CreateIntegrationMutationWithResponse(ctx context.Context, body CreateIntegrationMutationJSONRequestBody, reqEditors ...RequestEditorFn) (*CreateIntegrationMutationResponse, error)
-
-	// OneIntegrationQuery request
-	OneIntegrationQueryWithResponse(ctx context.Context, params *OneIntegrationQueryParams, reqEditors ...RequestEditorFn) (*OneIntegrationQueryResponse, error)
 
 	// DeleteIntegrationMutation request
 	DeleteIntegrationMutationWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*DeleteIntegrationMutationResponse, error)
@@ -2718,11 +2718,11 @@ type ClientWithResponsesInterface interface {
 	// OrganizationQuery request
 	OrganizationQueryWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*OrganizationQueryResponse, error)
 
-	// ServicesQuery request
-	ServicesQueryWithResponse(ctx context.Context, params *ServicesQueryParams, reqEditors ...RequestEditorFn) (*ServicesQueryResponse, error)
-
 	// OneServiceQuery request
 	OneServiceQueryWithResponse(ctx context.Context, params *OneServiceQueryParams, reqEditors ...RequestEditorFn) (*OneServiceQueryResponse, error)
+
+	// ServicesQuery request
+	ServicesQueryWithResponse(ctx context.Context, params *ServicesQueryParams, reqEditors ...RequestEditorFn) (*ServicesQueryResponse, error)
 
 	// ServiceQuery request
 	ServiceQueryWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*ServiceQueryResponse, error)
@@ -2740,6 +2740,28 @@ type ClientWithResponsesInterface interface {
 
 	// UserQuery request
 	UserQueryWithResponse(ctx context.Context, id string, reqEditors ...RequestEditorFn) (*UserQueryResponse, error)
+}
+
+type OneEnvironmentQueryResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *Environment
+}
+
+// Status returns HTTPResponse.Status
+func (r OneEnvironmentQueryResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r OneEnvironmentQueryResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
 }
 
 type EnvironmentsQueryResponse struct {
@@ -2852,28 +2874,6 @@ func (r AddEnvironmentLabelsMutationResponse) StatusCode() int {
 	return 0
 }
 
-type OneEnvironmentQueryResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *Environment
-}
-
-// Status returns HTTPResponse.Status
-func (r OneEnvironmentQueryResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r OneEnvironmentQueryResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
 type DeleteEnvironmentMutationResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -2912,6 +2912,28 @@ func (r EnvironmentQueryResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r EnvironmentQueryResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type OneIntegrationQueryResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *Integration
+}
+
+// Status returns HTTPResponse.Status
+func (r OneIntegrationQueryResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r OneIntegrationQueryResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -2978,28 +3000,6 @@ func (r CreateIntegrationMutationResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r CreateIntegrationMutationResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
-type OneIntegrationQueryResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *Integration
-}
-
-// Status returns HTTPResponse.Status
-func (r OneIntegrationQueryResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r OneIntegrationQueryResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -3314,28 +3314,6 @@ func (r OrganizationQueryResponse) StatusCode() int {
 	return 0
 }
 
-type ServicesQueryResponse struct {
-	Body         []byte
-	HTTPResponse *http.Response
-	JSON200      *[]Service
-}
-
-// Status returns HTTPResponse.Status
-func (r ServicesQueryResponse) Status() string {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.Status
-	}
-	return http.StatusText(0)
-}
-
-// StatusCode returns HTTPResponse.StatusCode
-func (r ServicesQueryResponse) StatusCode() int {
-	if r.HTTPResponse != nil {
-		return r.HTTPResponse.StatusCode
-	}
-	return 0
-}
-
 type OneServiceQueryResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
@@ -3352,6 +3330,28 @@ func (r OneServiceQueryResponse) Status() string {
 
 // StatusCode returns HTTPResponse.StatusCode
 func (r OneServiceQueryResponse) StatusCode() int {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.StatusCode
+	}
+	return 0
+}
+
+type ServicesQueryResponse struct {
+	Body         []byte
+	HTTPResponse *http.Response
+	JSON200      *[]Service
+}
+
+// Status returns HTTPResponse.Status
+func (r ServicesQueryResponse) Status() string {
+	if r.HTTPResponse != nil {
+		return r.HTTPResponse.Status
+	}
+	return http.StatusText(0)
+}
+
+// StatusCode returns HTTPResponse.StatusCode
+func (r ServicesQueryResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -3468,6 +3468,15 @@ func (r UserQueryResponse) StatusCode() int {
 	return 0
 }
 
+// OneEnvironmentQueryWithResponse request returning *OneEnvironmentQueryResponse
+func (c *ClientWithResponses) OneEnvironmentQueryWithResponse(ctx context.Context, params *OneEnvironmentQueryParams, reqEditors ...RequestEditorFn) (*OneEnvironmentQueryResponse, error) {
+	rsp, err := c.OneEnvironmentQuery(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseOneEnvironmentQueryResponse(rsp)
+}
+
 // EnvironmentsQueryWithResponse request returning *EnvironmentsQueryResponse
 func (c *ClientWithResponses) EnvironmentsQueryWithResponse(ctx context.Context, params *EnvironmentsQueryParams, reqEditors ...RequestEditorFn) (*EnvironmentsQueryResponse, error) {
 	rsp, err := c.EnvironmentsQuery(ctx, params, reqEditors...)
@@ -3537,15 +3546,6 @@ func (c *ClientWithResponses) AddEnvironmentLabelsMutationWithResponse(ctx conte
 	return ParseAddEnvironmentLabelsMutationResponse(rsp)
 }
 
-// OneEnvironmentQueryWithResponse request returning *OneEnvironmentQueryResponse
-func (c *ClientWithResponses) OneEnvironmentQueryWithResponse(ctx context.Context, params *OneEnvironmentQueryParams, reqEditors ...RequestEditorFn) (*OneEnvironmentQueryResponse, error) {
-	rsp, err := c.OneEnvironmentQuery(ctx, params, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseOneEnvironmentQueryResponse(rsp)
-}
-
 // DeleteEnvironmentMutationWithResponse request returning *DeleteEnvironmentMutationResponse
 func (c *ClientWithResponses) DeleteEnvironmentMutationWithResponse(ctx context.Context, id string, params *DeleteEnvironmentMutationParams, reqEditors ...RequestEditorFn) (*DeleteEnvironmentMutationResponse, error) {
 	rsp, err := c.DeleteEnvironmentMutation(ctx, id, params, reqEditors...)
@@ -3562,6 +3562,15 @@ func (c *ClientWithResponses) EnvironmentQueryWithResponse(ctx context.Context, 
 		return nil, err
 	}
 	return ParseEnvironmentQueryResponse(rsp)
+}
+
+// OneIntegrationQueryWithResponse request returning *OneIntegrationQueryResponse
+func (c *ClientWithResponses) OneIntegrationQueryWithResponse(ctx context.Context, params *OneIntegrationQueryParams, reqEditors ...RequestEditorFn) (*OneIntegrationQueryResponse, error) {
+	rsp, err := c.OneIntegrationQuery(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseOneIntegrationQueryResponse(rsp)
 }
 
 // IntegrationsQueryWithResponse request returning *IntegrationsQueryResponse
@@ -3605,15 +3614,6 @@ func (c *ClientWithResponses) CreateIntegrationMutationWithResponse(ctx context.
 		return nil, err
 	}
 	return ParseCreateIntegrationMutationResponse(rsp)
-}
-
-// OneIntegrationQueryWithResponse request returning *OneIntegrationQueryResponse
-func (c *ClientWithResponses) OneIntegrationQueryWithResponse(ctx context.Context, params *OneIntegrationQueryParams, reqEditors ...RequestEditorFn) (*OneIntegrationQueryResponse, error) {
-	rsp, err := c.OneIntegrationQuery(ctx, params, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseOneIntegrationQueryResponse(rsp)
 }
 
 // DeleteIntegrationMutationWithResponse request returning *DeleteIntegrationMutationResponse
@@ -3774,15 +3774,6 @@ func (c *ClientWithResponses) OrganizationQueryWithResponse(ctx context.Context,
 	return ParseOrganizationQueryResponse(rsp)
 }
 
-// ServicesQueryWithResponse request returning *ServicesQueryResponse
-func (c *ClientWithResponses) ServicesQueryWithResponse(ctx context.Context, params *ServicesQueryParams, reqEditors ...RequestEditorFn) (*ServicesQueryResponse, error) {
-	rsp, err := c.ServicesQuery(ctx, params, reqEditors...)
-	if err != nil {
-		return nil, err
-	}
-	return ParseServicesQueryResponse(rsp)
-}
-
 // OneServiceQueryWithResponse request returning *OneServiceQueryResponse
 func (c *ClientWithResponses) OneServiceQueryWithResponse(ctx context.Context, params *OneServiceQueryParams, reqEditors ...RequestEditorFn) (*OneServiceQueryResponse, error) {
 	rsp, err := c.OneServiceQuery(ctx, params, reqEditors...)
@@ -3790,6 +3781,15 @@ func (c *ClientWithResponses) OneServiceQueryWithResponse(ctx context.Context, p
 		return nil, err
 	}
 	return ParseOneServiceQueryResponse(rsp)
+}
+
+// ServicesQueryWithResponse request returning *ServicesQueryResponse
+func (c *ClientWithResponses) ServicesQueryWithResponse(ctx context.Context, params *ServicesQueryParams, reqEditors ...RequestEditorFn) (*ServicesQueryResponse, error) {
+	rsp, err := c.ServicesQuery(ctx, params, reqEditors...)
+	if err != nil {
+		return nil, err
+	}
+	return ParseServicesQueryResponse(rsp)
 }
 
 // ServiceQueryWithResponse request returning *ServiceQueryResponse
@@ -3843,6 +3843,32 @@ func (c *ClientWithResponses) UserQueryWithResponse(ctx context.Context, id stri
 		return nil, err
 	}
 	return ParseUserQueryResponse(rsp)
+}
+
+// ParseOneEnvironmentQueryResponse parses an HTTP response from a OneEnvironmentQueryWithResponse call
+func ParseOneEnvironmentQueryResponse(rsp *http.Response) (*OneEnvironmentQueryResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &OneEnvironmentQueryResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Environment
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
 }
 
 // ParseEnvironmentsQueryResponse parses an HTTP response from a EnvironmentsQueryWithResponse call
@@ -3975,32 +4001,6 @@ func ParseAddEnvironmentLabelsMutationResponse(rsp *http.Response) (*AddEnvironm
 	return response, nil
 }
 
-// ParseOneEnvironmentQueryResponse parses an HTTP response from a OneEnvironmentQueryWithResponse call
-func ParseOneEnvironmentQueryResponse(rsp *http.Response) (*OneEnvironmentQueryResponse, error) {
-	bodyBytes, err := io.ReadAll(rsp.Body)
-	defer func() { _ = rsp.Body.Close() }()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &OneEnvironmentQueryResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest Environment
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
-	}
-
-	return response, nil
-}
-
 // ParseDeleteEnvironmentMutationResponse parses an HTTP response from a DeleteEnvironmentMutationWithResponse call
 func ParseDeleteEnvironmentMutationResponse(rsp *http.Response) (*DeleteEnvironmentMutationResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -4043,6 +4043,32 @@ func ParseEnvironmentQueryResponse(rsp *http.Response) (*EnvironmentQueryRespons
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest Environment
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseOneIntegrationQueryResponse parses an HTTP response from a OneIntegrationQueryWithResponse call
+func ParseOneIntegrationQueryResponse(rsp *http.Response) (*OneIntegrationQueryResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &OneIntegrationQueryResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest Integration
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -4114,32 +4140,6 @@ func ParseCreateIntegrationMutationResponse(rsp *http.Response) (*CreateIntegrat
 	}
 
 	response := &CreateIntegrationMutationResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest Integration
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
-	}
-
-	return response, nil
-}
-
-// ParseOneIntegrationQueryResponse parses an HTTP response from a OneIntegrationQueryWithResponse call
-func ParseOneIntegrationQueryResponse(rsp *http.Response) (*OneIntegrationQueryResponse, error) {
-	bodyBytes, err := io.ReadAll(rsp.Body)
-	defer func() { _ = rsp.Body.Close() }()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &OneIntegrationQueryResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}
@@ -4521,32 +4521,6 @@ func ParseOrganizationQueryResponse(rsp *http.Response) (*OrganizationQueryRespo
 	return response, nil
 }
 
-// ParseServicesQueryResponse parses an HTTP response from a ServicesQueryWithResponse call
-func ParseServicesQueryResponse(rsp *http.Response) (*ServicesQueryResponse, error) {
-	bodyBytes, err := io.ReadAll(rsp.Body)
-	defer func() { _ = rsp.Body.Close() }()
-	if err != nil {
-		return nil, err
-	}
-
-	response := &ServicesQueryResponse{
-		Body:         bodyBytes,
-		HTTPResponse: rsp,
-	}
-
-	switch {
-	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest []Service
-		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
-			return nil, err
-		}
-		response.JSON200 = &dest
-
-	}
-
-	return response, nil
-}
-
 // ParseOneServiceQueryResponse parses an HTTP response from a OneServiceQueryWithResponse call
 func ParseOneServiceQueryResponse(rsp *http.Response) (*OneServiceQueryResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
@@ -4563,6 +4537,32 @@ func ParseOneServiceQueryResponse(rsp *http.Response) (*OneServiceQueryResponse,
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest Service
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON200 = &dest
+
+	}
+
+	return response, nil
+}
+
+// ParseServicesQueryResponse parses an HTTP response from a ServicesQueryWithResponse call
+func ParseServicesQueryResponse(rsp *http.Response) (*ServicesQueryResponse, error) {
+	bodyBytes, err := io.ReadAll(rsp.Body)
+	defer func() { _ = rsp.Body.Close() }()
+	if err != nil {
+		return nil, err
+	}
+
+	response := &ServicesQueryResponse{
+		Body:         bodyBytes,
+		HTTPResponse: rsp,
+	}
+
+	switch {
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
+		var dest []Service
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
* Bump API version after replacing /objects/one endpoint with /object
* Use oapi-codegen built-in security provider, simplify cloudclient init and struct