### PR TITLE
Read cloud API version, store it as part of codegen process, and issue warning if cloud version at runtime is different than it was at compile time

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@ generated.go linguist-generated=true
 *.gen.go linguist-generated=true
 go.mod linguist-generated=true
 go.sum linguist-generated=true
+openapi.json linguist-generated=true

--- a/src/cmd/root.go
+++ b/src/cmd/root.go
@@ -11,6 +11,7 @@ import (
 	"github.com/otterize/otterize-cli/src/cmd/organizations"
 	"github.com/otterize/otterize-cli/src/cmd/services"
 	"github.com/otterize/otterize-cli/src/cmd/users"
+	"github.com/otterize/otterize-cli/src/cmd/version"
 	"github.com/otterize/otterize-cli/src/pkg/config"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
@@ -81,6 +82,7 @@ func init() {
 	RootCmd.AddCommand(mapper.MapperCmd)
 	RootCmd.AddCommand(organizations.OrganizationsCmd)
 	RootCmd.AddCommand(users.UsersCmd)
+	RootCmd.AddCommand(version.ApiVersionCmd)
 }
 
 func initLogger() {

--- a/src/cmd/version/apiversion.go
+++ b/src/cmd/version/apiversion.go
@@ -37,7 +37,7 @@ This CLI was built against:
 		if cloudApiVersion != localApiVersion {
 			prints.PrintCliStderr(`
 Caution: this CLI was built with a different version/revision of the Otterize Cloud API. 
-Some cloud CLI commands may fail. 
+Some Cloud CLI commands may fail. 
 Upgrade your CLI to the latest build to resolve this issue.`)
 		} else {
 			prints.PrintCliOutput(`

--- a/src/cmd/version/apiversion.go
+++ b/src/cmd/version/apiversion.go
@@ -24,8 +24,26 @@ var ApiVersionCmd = &cobra.Command{
 			return err
 		}
 
-		prints.PrintCliOutput("Current Cloud API Version: %s", cloudApiVersion)
-		prints.PrintCliOutput("CLI was compiled with Cloud API Version: %s", localApiVersion)
+		prints.PrintCliOutput(
+			`Current Cloud API: 
+    version: %s 
+    revision: %s 
+This CLI was built against: 
+    version: %s 
+    revision: %s`,
+			cloudApiVersion.Version, cloudApiVersion.Revision,
+			localApiVersion.Version, localApiVersion.Revision)
+
+		if cloudApiVersion != localApiVersion {
+			prints.PrintCliStderr(`
+Caution: this CLI was built with a different version/revision of the Otterize Cloud API. 
+Some cloud CLI commands may fail. 
+Upgrade your CLI to the latest build to resolve this issue.`)
+		} else {
+			prints.PrintCliOutput(`
+This CLI was built using the latest version & revision of the Otterize Cloud API.`)
+		}
+
 		return nil
 	},
 }

--- a/src/cmd/version/apiversion.go
+++ b/src/cmd/version/apiversion.go
@@ -1,0 +1,31 @@
+package version
+
+import (
+	"github.com/otterize/otterize-cli/src/pkg/cloudclient/restapi"
+	"github.com/otterize/otterize-cli/src/pkg/config"
+	"github.com/otterize/otterize-cli/src/pkg/utils/prints"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var ApiVersionCmd = &cobra.Command{
+	Use:          "api-version",
+	Short:        "Get the Otterize api version",
+	Args:         cobra.NoArgs,
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, args []string) error {
+		localApiVersion, err := restapi.GetLocalApiVersion()
+		if err != nil {
+			return err
+		}
+
+		cloudApiVersion, err := restapi.GetCloudApiVersion(viper.GetString(config.OtterizeAPIAddressKey))
+		if err != nil {
+			return err
+		}
+
+		prints.PrintCliOutput("Current Cloud API Version: %s", cloudApiVersion)
+		prints.PrintCliOutput("CLI was compiled with Cloud API Version: %s", localApiVersion)
+		return nil
+	},
+}

--- a/src/pkg/cloudclient/restapi/client.go
+++ b/src/pkg/cloudclient/restapi/client.go
@@ -6,6 +6,7 @@ import (
 	"github.com/deepmap/oapi-codegen/pkg/securityprovider"
 	"github.com/otterize/otterize-cli/src/pkg/cloudclient/restapi/cloudapi"
 	"github.com/otterize/otterize-cli/src/pkg/config"
+	"github.com/otterize/otterize-cli/src/pkg/utils/prints"
 	"github.com/spf13/viper"
 	"net/http"
 )
@@ -15,6 +16,24 @@ type Doer interface {
 }
 
 func NewClientFromToken(address string, token string) (*cloudapi.ClientWithResponses, error) {
+	localApiVersion, err := GetLocalApiVersion()
+	if err != nil {
+		return nil, err
+	}
+
+	cloudApiVersion, err := GetCloudApiVersion(address)
+	if err != nil {
+		return nil, err
+	}
+
+	if localApiVersion != cloudApiVersion {
+		prints.PrintCliStderr("Warning: Cloud API version %s is different from the CLI build API version %s.\n"+
+			"Some cloud CLI commands may fail.\n"+
+			"To resolve, upgrade your CLI to the latest version.\n",
+			cloudApiVersion, localApiVersion,
+		)
+	}
+
 	address = address + "/rest/v1beta"
 	bearerTokenProvider, err := securityprovider.NewSecurityProviderBearerToken(token)
 	if err != nil {

--- a/src/pkg/cloudclient/restapi/client.go
+++ b/src/pkg/cloudclient/restapi/client.go
@@ -28,7 +28,7 @@ func NewClientFromToken(address string, token string) (*cloudapi.ClientWithRespo
 
 	if localApiVersion != cloudApiVersion {
 		prints.PrintCliStderr(`
-Caution: this CLI was built with a different version of the Otterize Cloud API.
+Caution: this CLI was built with a different version/revision of the Otterize Cloud API.
 Please run otterize api-version for more info.
 `,
 		)

--- a/src/pkg/cloudclient/restapi/client.go
+++ b/src/pkg/cloudclient/restapi/client.go
@@ -27,10 +27,10 @@ func NewClientFromToken(address string, token string) (*cloudapi.ClientWithRespo
 	}
 
 	if localApiVersion != cloudApiVersion {
-		prints.PrintCliStderr("Warning: Cloud API version %s is different from the CLI build API version %s.\n"+
-			"Some cloud CLI commands may fail.\n"+
-			"To resolve, upgrade your CLI to the latest version.\n",
-			cloudApiVersion, localApiVersion,
+		prints.PrintCliStderr(`
+Caution: this CLI was built with a different version of the Otterize Cloud API.
+Please run otterize api-version for more info.
+`,
 		)
 	}
 

--- a/src/pkg/cloudclient/restapi/cloudapi/api.gen.go
+++ b/src/pkg/cloudclient/restapi/cloudapi/api.gen.go
@@ -65,16 +65,16 @@ const (
 	EdgeAccessStatusVerdictWOULDBEBLOCKED    EdgeAccessStatusVerdict = "WOULD_BE_BLOCKED"
 )
 
-// Defines values for HTTPConfigMethod.
+// Defines values for HTTPConfigMethods.
 const (
-	HTTPConfigMethodCONNECT HTTPConfigMethod = "CONNECT"
-	HTTPConfigMethodDELETE  HTTPConfigMethod = "DELETE"
-	HTTPConfigMethodGET     HTTPConfigMethod = "GET"
-	HTTPConfigMethodOPTIONS HTTPConfigMethod = "OPTIONS"
-	HTTPConfigMethodPATCH   HTTPConfigMethod = "PATCH"
-	HTTPConfigMethodPOST    HTTPConfigMethod = "POST"
-	HTTPConfigMethodPUT     HTTPConfigMethod = "PUT"
-	HTTPConfigMethodTRACE   HTTPConfigMethod = "TRACE"
+	HTTPConfigMethodsCONNECT HTTPConfigMethods = "CONNECT"
+	HTTPConfigMethodsDELETE  HTTPConfigMethods = "DELETE"
+	HTTPConfigMethodsGET     HTTPConfigMethods = "GET"
+	HTTPConfigMethodsOPTIONS HTTPConfigMethods = "OPTIONS"
+	HTTPConfigMethodsPATCH   HTTPConfigMethods = "PATCH"
+	HTTPConfigMethodsPOST    HTTPConfigMethods = "POST"
+	HTTPConfigMethodsPUT     HTTPConfigMethods = "PUT"
+	HTTPConfigMethodsTRACE   HTTPConfigMethods = "TRACE"
 )
 
 // Defines values for IntegrationType.
@@ -315,12 +315,12 @@ type Error struct {
 
 // HTTPConfig defines model for HTTPConfig.
 type HTTPConfig struct {
-	Method *HTTPConfigMethod `json:"method,omitempty"`
-	Path   *string           `json:"path,omitempty"`
+	Methods *[]HTTPConfigMethods `json:"methods,omitempty"`
+	Path    *string              `json:"path,omitempty"`
 }
 
-// HTTPConfigMethod defines model for HTTPConfig.Method.
-type HTTPConfigMethod string
+// HTTPConfigMethods defines model for HTTPConfig.Methods.
+type HTTPConfigMethods string
 
 // InputAccessGraphFilter defines model for InputAccessGraphFilter.
 type InputAccessGraphFilter struct {
@@ -369,10 +369,10 @@ type Intent struct {
 	Client struct {
 		Id string `json:"id"`
 	} `json:"client"`
-	HttpResources  *[]HTTPConfig  `json:"httpResources,omitempty"`
-	Id             string         `json:"id"`
-	KafkaResources *[]KafkaConfig `json:"kafkaResources,omitempty"`
-	Server         struct {
+	HttpResources *[]HTTPConfig  `json:"httpResources,omitempty"`
+	Id            string         `json:"id"`
+	KafkaTopics   *[]KafkaConfig `json:"kafkaTopics,omitempty"`
+	Server        struct {
 		Id string `json:"id"`
 	} `json:"server"`
 	Type *IntentType `json:"type,omitempty"`
@@ -664,7 +664,6 @@ type IntentsQueryParams struct {
 	EnvironmentId *string `form:"environmentId,omitempty" json:"environmentId,omitempty"`
 	ClientId      *string `form:"clientId,omitempty" json:"clientId,omitempty"`
 	ServerId      *string `form:"serverId,omitempty" json:"serverId,omitempty"`
-	Source        *string `form:"source,omitempty" json:"source,omitempty"`
 }
 
 // OneInviteQueryParams defines parameters for OneInviteQuery.
@@ -2633,22 +2632,6 @@ func NewIntentsQueryRequest(server string, params *IntentsQueryParams) (*http.Re
 	if params.ServerId != nil {
 
 		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "serverId", runtime.ParamLocationQuery, *params.ServerId); err != nil {
-			return nil, err
-		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-			return nil, err
-		} else {
-			for k, v := range parsed {
-				for _, v2 := range v {
-					queryValues.Add(k, v2)
-				}
-			}
-		}
-
-	}
-
-	if params.Source != nil {
-
-		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "source", runtime.ParamLocationQuery, *params.Source); err != nil {
 			return nil, err
 		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
 			return nil, err

--- a/src/pkg/cloudclient/restapi/cloudapi/api.gen.go
+++ b/src/pkg/cloudclient/restapi/cloudapi/api.gen.go
@@ -32,9 +32,9 @@ const (
 
 // Defines values for ComponentStatusType.
 const (
-	ComponentStatusTypeCONNECTED      ComponentStatusType = "CONNECTED"
-	ComponentStatusTypeDISCONNECTED   ComponentStatusType = "DISCONNECTED"
-	ComponentStatusTypeNEVERCONNECTED ComponentStatusType = "NEVER_CONNECTED"
+	ComponentStatusTypeCONNECTED     ComponentStatusType = "CONNECTED"
+	ComponentStatusTypeDISCONNECTED  ComponentStatusType = "DISCONNECTED"
+	ComponentStatusTypeNOTINTEGRATED ComponentStatusType = "NOT_INTEGRATED"
 )
 
 // Defines values for CredentialsOperatorComponentType.
@@ -46,13 +46,14 @@ const (
 
 // Defines values for EdgeAccessStatusReason.
 const (
-	EdgeAccessStatusReasonALLOWEDBYAPPLIEDINTENTS                 EdgeAccessStatusReason = "ALLOWED_BY_APPLIED_INTENTS"
-	EdgeAccessStatusReasonALLOWEDBYAPPLIEDINTENTSOVERLYPERMISSIVE EdgeAccessStatusReason = "ALLOWED_BY_APPLIED_INTENTS_OVERLY_PERMISSIVE"
-	EdgeAccessStatusReasonBLOCKEDBYDEFAULTDENY                    EdgeAccessStatusReason = "BLOCKED_BY_DEFAULT_DENY"
-	EdgeAccessStatusReasonINTENTSOPERATORNEVERCONNECTED           EdgeAccessStatusReason = "INTENTS_OPERATOR_NEVER_CONNECTED"
-	EdgeAccessStatusReasonINTENTSOPERATORNOTENFORCING             EdgeAccessStatusReason = "INTENTS_OPERATOR_NOT_ENFORCING"
-	EdgeAccessStatusReasonMISSINGAPPLIEDINTENT                    EdgeAccessStatusReason = "MISSING_APPLIED_INTENT"
-	EdgeAccessStatusReasonNETWORKMAPPERNEVERCONNECTED             EdgeAccessStatusReason = "NETWORK_MAPPER_NEVER_CONNECTED"
+	EdgeAccessStatusReasonALLOWEDBYAPPLIEDINTENTS                         EdgeAccessStatusReason = "ALLOWED_BY_APPLIED_INTENTS"
+	EdgeAccessStatusReasonALLOWEDBYAPPLIEDINTENTSOVERLYPERMISSIVE         EdgeAccessStatusReason = "ALLOWED_BY_APPLIED_INTENTS_OVERLY_PERMISSIVE"
+	EdgeAccessStatusReasonBLOCKEDBYDEFAULTDENY                            EdgeAccessStatusReason = "BLOCKED_BY_DEFAULT_DENY"
+	EdgeAccessStatusReasonINTENTSOPERATORNEVERCONNECTED                   EdgeAccessStatusReason = "INTENTS_OPERATOR_NEVER_CONNECTED"
+	EdgeAccessStatusReasonINTENTSOPERATORNOTENFORCING                     EdgeAccessStatusReason = "INTENTS_OPERATOR_NOT_ENFORCING"
+	EdgeAccessStatusReasonINTENTSOPERATORNOTENFORCINGMISSINGAPPLIEDINTENT EdgeAccessStatusReason = "INTENTS_OPERATOR_NOT_ENFORCING_MISSING_APPLIED_INTENT"
+	EdgeAccessStatusReasonMISSINGAPPLIEDINTENT                            EdgeAccessStatusReason = "MISSING_APPLIED_INTENT"
+	EdgeAccessStatusReasonNETWORKMAPPERNEVERCONNECTED                     EdgeAccessStatusReason = "NETWORK_MAPPER_NEVER_CONNECTED"
 )
 
 // Defines values for EdgeAccessStatusVerdict.
@@ -103,6 +104,7 @@ const (
 
 // Defines values for KafkaConfigOperations.
 const (
+	KafkaConfigOperationsALL             KafkaConfigOperations = "ALL"
 	KafkaConfigOperationsALTER           KafkaConfigOperations = "ALTER"
 	KafkaConfigOperationsALTERCONFIGS    KafkaConfigOperations = "ALTER_CONFIGS"
 	KafkaConfigOperationsCLUSTERACTION   KafkaConfigOperations = "CLUSTER_ACTION"
@@ -218,6 +220,7 @@ type AccessGraphFilter struct {
 	EnvironmentIds             *[]string  `json:"environmentIds,omitempty"`
 	IncludeServicesWithNoEdges *bool      `json:"includeServicesWithNoEdges,omitempty"`
 	LastSeenAfter              *time.Time `json:"lastSeenAfter,omitempty"`
+	NamespaceIds               *[]string  `json:"namespaceIds,omitempty"`
 	ServiceIds                 *[]string  `json:"serviceIds,omitempty"`
 }
 
@@ -325,6 +328,7 @@ type InputAccessGraphFilter struct {
 	EnvironmentIds             *[]string  `json:"environmentIds,omitempty"`
 	IncludeServicesWithNoEdges *bool      `json:"includeServicesWithNoEdges,omitempty"`
 	LastSeenAfter              *time.Time `json:"lastSeenAfter,omitempty"`
+	NamespaceIds               *[]string  `json:"namespaceIds,omitempty"`
 	ServiceIds                 *[]string  `json:"serviceIds,omitempty"`
 }
 
@@ -645,7 +649,7 @@ type CreateGenericIntegrationMutationJSONBody struct {
 
 // CreateKubernetesIntegrationMutationJSONBody defines parameters for CreateKubernetesIntegrationMutation.
 type CreateKubernetesIntegrationMutationJSONBody struct {
-	ClusterId     *string `json:"clusterId,omitempty"`
+	ClusterId     string  `json:"clusterId"`
 	EnvironmentId *string `json:"environmentId,omitempty"`
 	Name          string  `json:"name"`
 }

--- a/src/pkg/cloudclient/restapi/cloudapi/openapi.json
+++ b/src/pkg/cloudclient/restapi/cloudapi/openapi.json
@@ -1,0 +1,3592 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Otterize API Server",
+    "version": "6ec4575de806fb55ec4aa2cab95e94debffacc67"
+  },
+  "servers": [
+    {
+      "url": "/api/rest/v1beta",
+      "description": "Otterize API Server"
+    }
+  ],
+  "tags": [],
+  "paths": {
+    "/access-graph": {
+      "post": {
+        "tags": [
+          "access graph"
+        ],
+        "description": "Get access graph",
+        "summary": "Get access graph",
+        "operationId": "accessGraph_query",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "filter": {
+                    "$ref": "#/components/schemas/InputAccessGraphFilter"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Get access graph",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AccessGraph"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BAD_REQUEST"
+          },
+          "403": {
+            "$ref": "#/components/responses/FORBIDDEN"
+          },
+          "404": {
+            "$ref": "#/components/responses/NOT_FOUND"
+          },
+          "409": {
+            "$ref": "#/components/responses/CONFLICT"
+          },
+          "500": {
+            "$ref": "#/components/responses/INTERNAL_SERVER_ERROR"
+          },
+          "default": {
+            "$ref": "#/components/responses/UNEXPECTED_ERROR"
+          }
+        }
+      }
+    },
+    "/clusters/{id}": {
+      "get": {
+        "tags": [
+          "clusters"
+        ],
+        "description": "Get cluster",
+        "summary": "Get cluster",
+        "operationId": "cluster_query",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Get cluster",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Cluster"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BAD_REQUEST"
+          },
+          "403": {
+            "$ref": "#/components/responses/FORBIDDEN"
+          },
+          "404": {
+            "$ref": "#/components/responses/NOT_FOUND"
+          },
+          "409": {
+            "$ref": "#/components/responses/CONFLICT"
+          },
+          "500": {
+            "$ref": "#/components/responses/INTERNAL_SERVER_ERROR"
+          },
+          "default": {
+            "$ref": "#/components/responses/UNEXPECTED_ERROR"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "clusters"
+        ],
+        "description": "Update cluster",
+        "summary": "Update cluster",
+        "operationId": "updateCluster_mutation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "configuration": {
+                    "$ref": "#/components/schemas/ClusterConfigurationInput"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Update cluster",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Cluster"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BAD_REQUEST"
+          },
+          "403": {
+            "$ref": "#/components/responses/FORBIDDEN"
+          },
+          "404": {
+            "$ref": "#/components/responses/NOT_FOUND"
+          },
+          "409": {
+            "$ref": "#/components/responses/CONFLICT"
+          },
+          "500": {
+            "$ref": "#/components/responses/INTERNAL_SERVER_ERROR"
+          },
+          "default": {
+            "$ref": "#/components/responses/UNEXPECTED_ERROR"
+          }
+        }
+      }
+    },
+    "/clusters": {
+      "get": {
+        "tags": [
+          "clusters"
+        ],
+        "description": "List clusters",
+        "summary": "List clusters",
+        "operationId": "clusters_query",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "List clusters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Cluster"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BAD_REQUEST"
+          },
+          "403": {
+            "$ref": "#/components/responses/FORBIDDEN"
+          },
+          "404": {
+            "$ref": "#/components/responses/NOT_FOUND"
+          },
+          "409": {
+            "$ref": "#/components/responses/CONFLICT"
+          },
+          "500": {
+            "$ref": "#/components/responses/INTERNAL_SERVER_ERROR"
+          },
+          "default": {
+            "$ref": "#/components/responses/UNEXPECTED_ERROR"
+          }
+        }
+      }
+    },
+    "/cluster": {
+      "get": {
+        "tags": [
+          "clusters"
+        ],
+        "description": "Get cluster by filters",
+        "summary": "Get cluster by filters",
+        "operationId": "oneCluster_query",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Get cluster by filters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Cluster"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BAD_REQUEST"
+          },
+          "403": {
+            "$ref": "#/components/responses/FORBIDDEN"
+          },
+          "404": {
+            "$ref": "#/components/responses/NOT_FOUND"
+          },
+          "409": {
+            "$ref": "#/components/responses/CONFLICT"
+          },
+          "500": {
+            "$ref": "#/components/responses/INTERNAL_SERVER_ERROR"
+          },
+          "default": {
+            "$ref": "#/components/responses/UNEXPECTED_ERROR"
+          }
+        }
+      }
+    },
+    "/environments/{id}": {
+      "get": {
+        "tags": [
+          "environments"
+        ],
+        "description": "Get environment",
+        "summary": "Get environment",
+        "operationId": "environment_query",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Get environment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Environment"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BAD_REQUEST"
+          },
+          "403": {
+            "$ref": "#/components/responses/FORBIDDEN"
+          },
+          "404": {
+            "$ref": "#/components/responses/NOT_FOUND"
+          },
+          "409": {
+            "$ref": "#/components/responses/CONFLICT"
+          },
+          "500": {
+            "$ref": "#/components/responses/INTERNAL_SERVER_ERROR"
+          },
+          "default": {
+            "$ref": "#/components/responses/UNEXPECTED_ERROR"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "environments"
+        ],
+        "description": "Update environment",
+        "summary": "Update environment",
+        "operationId": "updateEnvironment_mutation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "labels": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/LabelInput"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Update environment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Environment"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BAD_REQUEST"
+          },
+          "403": {
+            "$ref": "#/components/responses/FORBIDDEN"
+          },
+          "404": {
+            "$ref": "#/components/responses/NOT_FOUND"
+          },
+          "409": {
+            "$ref": "#/components/responses/CONFLICT"
+          },
+          "500": {
+            "$ref": "#/components/responses/INTERNAL_SERVER_ERROR"
+          },
+          "default": {
+            "$ref": "#/components/responses/UNEXPECTED_ERROR"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "environments"
+        ],
+        "description": "Delete environment",
+        "summary": "Delete environment",
+        "operationId": "deleteEnvironment_mutation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Delete environment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BAD_REQUEST"
+          },
+          "403": {
+            "$ref": "#/components/responses/FORBIDDEN"
+          },
+          "404": {
+            "$ref": "#/components/responses/NOT_FOUND"
+          },
+          "409": {
+            "$ref": "#/components/responses/CONFLICT"
+          },
+          "500": {
+            "$ref": "#/components/responses/INTERNAL_SERVER_ERROR"
+          },
+          "default": {
+            "$ref": "#/components/responses/UNEXPECTED_ERROR"
+          }
+        }
+      }
+    },
+    "/environments": {
+      "get": {
+        "tags": [
+          "environments"
+        ],
+        "description": "List environments",
+        "summary": "List environments",
+        "operationId": "environments_query",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "name",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "labels",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/LabelInput"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List environments",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Environment"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BAD_REQUEST"
+          },
+          "403": {
+            "$ref": "#/components/responses/FORBIDDEN"
+          },
+          "404": {
+            "$ref": "#/components/responses/NOT_FOUND"
+          },
+          "409": {
+            "$ref": "#/components/responses/CONFLICT"
+          },
+          "500": {
+            "$ref": "#/components/responses/INTERNAL_SERVER_ERROR"
+          },
+          "default": {
+            "$ref": "#/components/responses/UNEXPECTED_ERROR"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "environments"
+        ],
+        "description": "Create a new environment",
+        "summary": "Create a new environment",
+        "operationId": "createEnvironment_mutation",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "labels": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/LabelInput"
+                    }
+                  }
+                },
+                "required": [
+                  "name"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Create a new environment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Environment"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BAD_REQUEST"
+          },
+          "403": {
+            "$ref": "#/components/responses/FORBIDDEN"
+          },
+          "404": {
+            "$ref": "#/components/responses/NOT_FOUND"
+          },
+          "409": {
+            "$ref": "#/components/responses/CONFLICT"
+          },
+          "500": {
+            "$ref": "#/components/responses/INTERNAL_SERVER_ERROR"
+          },
+          "default": {
+            "$ref": "#/components/responses/UNEXPECTED_ERROR"
+          }
+        }
+      }
+    },
+    "/environment": {
+      "get": {
+        "tags": [
+          "environments"
+        ],
+        "description": "Get environment by filters",
+        "summary": "Get environment by filters",
+        "operationId": "oneEnvironment_query",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Get environment by filters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Environment"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BAD_REQUEST"
+          },
+          "403": {
+            "$ref": "#/components/responses/FORBIDDEN"
+          },
+          "404": {
+            "$ref": "#/components/responses/NOT_FOUND"
+          },
+          "409": {
+            "$ref": "#/components/responses/CONFLICT"
+          },
+          "500": {
+            "$ref": "#/components/responses/INTERNAL_SERVER_ERROR"
+          },
+          "default": {
+            "$ref": "#/components/responses/UNEXPECTED_ERROR"
+          }
+        }
+      }
+    },
+    "/integrations": {
+      "get": {
+        "tags": [
+          "integrations"
+        ],
+        "description": "List integrations",
+        "summary": "List integrations",
+        "operationId": "integrations_query",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "name",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "integrationType",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "GENERIC",
+                "KUBERNETES"
+              ]
+            }
+          },
+          {
+            "in": "query",
+            "name": "environmentId",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "clusterId",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List integrations",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Integration"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BAD_REQUEST"
+          },
+          "403": {
+            "$ref": "#/components/responses/FORBIDDEN"
+          },
+          "404": {
+            "$ref": "#/components/responses/NOT_FOUND"
+          },
+          "409": {
+            "$ref": "#/components/responses/CONFLICT"
+          },
+          "500": {
+            "$ref": "#/components/responses/INTERNAL_SERVER_ERROR"
+          },
+          "default": {
+            "$ref": "#/components/responses/UNEXPECTED_ERROR"
+          }
+        }
+      }
+    },
+    "/integrations/{id}": {
+      "get": {
+        "tags": [
+          "integrations"
+        ],
+        "description": "Get integration",
+        "summary": "Get integration",
+        "operationId": "integration_query",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Get integration",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Integration"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BAD_REQUEST"
+          },
+          "403": {
+            "$ref": "#/components/responses/FORBIDDEN"
+          },
+          "404": {
+            "$ref": "#/components/responses/NOT_FOUND"
+          },
+          "409": {
+            "$ref": "#/components/responses/CONFLICT"
+          },
+          "500": {
+            "$ref": "#/components/responses/INTERNAL_SERVER_ERROR"
+          },
+          "default": {
+            "$ref": "#/components/responses/UNEXPECTED_ERROR"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "integrations"
+        ],
+        "description": "Update integration",
+        "summary": "Update integration",
+        "operationId": "updateIntegration_mutation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Update integration",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Integration"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BAD_REQUEST"
+          },
+          "403": {
+            "$ref": "#/components/responses/FORBIDDEN"
+          },
+          "404": {
+            "$ref": "#/components/responses/NOT_FOUND"
+          },
+          "409": {
+            "$ref": "#/components/responses/CONFLICT"
+          },
+          "500": {
+            "$ref": "#/components/responses/INTERNAL_SERVER_ERROR"
+          },
+          "default": {
+            "$ref": "#/components/responses/UNEXPECTED_ERROR"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "integrations"
+        ],
+        "description": "Delete integration",
+        "summary": "Delete integration",
+        "operationId": "deleteIntegration_mutation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Delete integration",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BAD_REQUEST"
+          },
+          "403": {
+            "$ref": "#/components/responses/FORBIDDEN"
+          },
+          "404": {
+            "$ref": "#/components/responses/NOT_FOUND"
+          },
+          "409": {
+            "$ref": "#/components/responses/CONFLICT"
+          },
+          "500": {
+            "$ref": "#/components/responses/INTERNAL_SERVER_ERROR"
+          },
+          "default": {
+            "$ref": "#/components/responses/UNEXPECTED_ERROR"
+          }
+        }
+      }
+    },
+    "/integration": {
+      "get": {
+        "tags": [
+          "integrations"
+        ],
+        "description": "Get integration by filters",
+        "summary": "Get integration by filters",
+        "operationId": "oneIntegration_query",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "integrationType",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "GENERIC",
+                "KUBERNETES"
+              ]
+            }
+          },
+          {
+            "in": "query",
+            "name": "environmentId",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "clusterId",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "name",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Get integration by filters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Integration"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BAD_REQUEST"
+          },
+          "403": {
+            "$ref": "#/components/responses/FORBIDDEN"
+          },
+          "404": {
+            "$ref": "#/components/responses/NOT_FOUND"
+          },
+          "409": {
+            "$ref": "#/components/responses/CONFLICT"
+          },
+          "500": {
+            "$ref": "#/components/responses/INTERNAL_SERVER_ERROR"
+          },
+          "default": {
+            "$ref": "#/components/responses/UNEXPECTED_ERROR"
+          }
+        }
+      }
+    },
+    "/intents/{id}": {
+      "get": {
+        "tags": [
+          "intents"
+        ],
+        "description": "Get intent",
+        "summary": "Get intent",
+        "operationId": "intent_query",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Get intent",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Intent"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BAD_REQUEST"
+          },
+          "403": {
+            "$ref": "#/components/responses/FORBIDDEN"
+          },
+          "404": {
+            "$ref": "#/components/responses/NOT_FOUND"
+          },
+          "409": {
+            "$ref": "#/components/responses/CONFLICT"
+          },
+          "500": {
+            "$ref": "#/components/responses/INTERNAL_SERVER_ERROR"
+          },
+          "default": {
+            "$ref": "#/components/responses/UNEXPECTED_ERROR"
+          }
+        }
+      }
+    },
+    "/intents": {
+      "get": {
+        "tags": [
+          "intents"
+        ],
+        "description": "List intents",
+        "summary": "List intents",
+        "operationId": "intents_query",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "environmentId",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "clientId",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "serverId",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "source",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List intents",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Intent"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BAD_REQUEST"
+          },
+          "403": {
+            "$ref": "#/components/responses/FORBIDDEN"
+          },
+          "404": {
+            "$ref": "#/components/responses/NOT_FOUND"
+          },
+          "409": {
+            "$ref": "#/components/responses/CONFLICT"
+          },
+          "500": {
+            "$ref": "#/components/responses/INTERNAL_SERVER_ERROR"
+          },
+          "default": {
+            "$ref": "#/components/responses/UNEXPECTED_ERROR"
+          }
+        }
+      }
+    },
+    "/invites": {
+      "get": {
+        "tags": [
+          "invites"
+        ],
+        "description": "List user invites",
+        "summary": "List user invites",
+        "operationId": "invites_query",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "email",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "PENDING",
+                "ACCEPTED"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List user invites",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Invite"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BAD_REQUEST"
+          },
+          "403": {
+            "$ref": "#/components/responses/FORBIDDEN"
+          },
+          "404": {
+            "$ref": "#/components/responses/NOT_FOUND"
+          },
+          "409": {
+            "$ref": "#/components/responses/CONFLICT"
+          },
+          "500": {
+            "$ref": "#/components/responses/INTERNAL_SERVER_ERROR"
+          },
+          "default": {
+            "$ref": "#/components/responses/UNEXPECTED_ERROR"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "invites"
+        ],
+        "description": "Create user invite",
+        "summary": "Create user invite",
+        "operationId": "createInvite_mutation",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "email": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "email"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Create user invite",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Invite"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BAD_REQUEST"
+          },
+          "403": {
+            "$ref": "#/components/responses/FORBIDDEN"
+          },
+          "404": {
+            "$ref": "#/components/responses/NOT_FOUND"
+          },
+          "409": {
+            "$ref": "#/components/responses/CONFLICT"
+          },
+          "500": {
+            "$ref": "#/components/responses/INTERNAL_SERVER_ERROR"
+          },
+          "default": {
+            "$ref": "#/components/responses/UNEXPECTED_ERROR"
+          }
+        }
+      }
+    },
+    "/invites/{id}": {
+      "get": {
+        "tags": [
+          "invites"
+        ],
+        "description": "Get user invite",
+        "summary": "Get user invite",
+        "operationId": "invite_query",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Get user invite",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Invite"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BAD_REQUEST"
+          },
+          "403": {
+            "$ref": "#/components/responses/FORBIDDEN"
+          },
+          "404": {
+            "$ref": "#/components/responses/NOT_FOUND"
+          },
+          "409": {
+            "$ref": "#/components/responses/CONFLICT"
+          },
+          "500": {
+            "$ref": "#/components/responses/INTERNAL_SERVER_ERROR"
+          },
+          "default": {
+            "$ref": "#/components/responses/UNEXPECTED_ERROR"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "invites"
+        ],
+        "description": "Delete user invite",
+        "summary": "Delete user invite",
+        "operationId": "deleteInvite_mutation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Delete user invite",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BAD_REQUEST"
+          },
+          "403": {
+            "$ref": "#/components/responses/FORBIDDEN"
+          },
+          "404": {
+            "$ref": "#/components/responses/NOT_FOUND"
+          },
+          "409": {
+            "$ref": "#/components/responses/CONFLICT"
+          },
+          "500": {
+            "$ref": "#/components/responses/INTERNAL_SERVER_ERROR"
+          },
+          "default": {
+            "$ref": "#/components/responses/UNEXPECTED_ERROR"
+          }
+        }
+      }
+    },
+    "/invite": {
+      "get": {
+        "tags": [
+          "invites"
+        ],
+        "description": "Get one user invite",
+        "summary": "Get one user invite",
+        "operationId": "oneInvite_query",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "email",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "PENDING",
+                "ACCEPTED"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Get one user invite",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Invite"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BAD_REQUEST"
+          },
+          "403": {
+            "$ref": "#/components/responses/FORBIDDEN"
+          },
+          "404": {
+            "$ref": "#/components/responses/NOT_FOUND"
+          },
+          "409": {
+            "$ref": "#/components/responses/CONFLICT"
+          },
+          "500": {
+            "$ref": "#/components/responses/INTERNAL_SERVER_ERROR"
+          },
+          "default": {
+            "$ref": "#/components/responses/UNEXPECTED_ERROR"
+          }
+        }
+      }
+    },
+    "/me": {
+      "get": {
+        "tags": [
+          "me"
+        ],
+        "description": "Get information regarding the current logged-in user",
+        "summary": "Get information regarding the current logged-in user",
+        "operationId": "me_query",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Get information regarding the current logged-in user",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Me"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BAD_REQUEST"
+          },
+          "403": {
+            "$ref": "#/components/responses/FORBIDDEN"
+          },
+          "404": {
+            "$ref": "#/components/responses/NOT_FOUND"
+          },
+          "409": {
+            "$ref": "#/components/responses/CONFLICT"
+          },
+          "500": {
+            "$ref": "#/components/responses/INTERNAL_SERVER_ERROR"
+          },
+          "default": {
+            "$ref": "#/components/responses/UNEXPECTED_ERROR"
+          }
+        }
+      }
+    },
+    "/namespaces/{id}": {
+      "get": {
+        "tags": [
+          "namespace"
+        ],
+        "description": "Get namespace",
+        "summary": "Get namespace",
+        "operationId": "namespace_query",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Get namespace",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Namespace"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BAD_REQUEST"
+          },
+          "403": {
+            "$ref": "#/components/responses/FORBIDDEN"
+          },
+          "404": {
+            "$ref": "#/components/responses/NOT_FOUND"
+          },
+          "409": {
+            "$ref": "#/components/responses/CONFLICT"
+          },
+          "500": {
+            "$ref": "#/components/responses/INTERNAL_SERVER_ERROR"
+          },
+          "default": {
+            "$ref": "#/components/responses/UNEXPECTED_ERROR"
+          }
+        }
+      }
+    },
+    "/namespaces": {
+      "get": {
+        "tags": [
+          "namespaces"
+        ],
+        "description": "List namespaces",
+        "summary": "List namespaces",
+        "operationId": "namespaces_query",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "environmentId",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "clusterId",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "name",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List namespaces",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Namespace"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BAD_REQUEST"
+          },
+          "403": {
+            "$ref": "#/components/responses/FORBIDDEN"
+          },
+          "404": {
+            "$ref": "#/components/responses/NOT_FOUND"
+          },
+          "409": {
+            "$ref": "#/components/responses/CONFLICT"
+          },
+          "500": {
+            "$ref": "#/components/responses/INTERNAL_SERVER_ERROR"
+          },
+          "default": {
+            "$ref": "#/components/responses/UNEXPECTED_ERROR"
+          }
+        }
+      }
+    },
+    "/namespace": {
+      "get": {
+        "tags": [
+          "namespaces"
+        ],
+        "description": "Get one namespace",
+        "summary": "Get one namespace",
+        "operationId": "oneNamespace_query",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "environmentId",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "clusterId",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "name",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Get one namespace",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Namespace"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BAD_REQUEST"
+          },
+          "403": {
+            "$ref": "#/components/responses/FORBIDDEN"
+          },
+          "404": {
+            "$ref": "#/components/responses/NOT_FOUND"
+          },
+          "409": {
+            "$ref": "#/components/responses/CONFLICT"
+          },
+          "500": {
+            "$ref": "#/components/responses/INTERNAL_SERVER_ERROR"
+          },
+          "default": {
+            "$ref": "#/components/responses/UNEXPECTED_ERROR"
+          }
+        }
+      }
+    },
+    "/organizations": {
+      "get": {
+        "tags": [
+          "organizations"
+        ],
+        "description": "List organizations",
+        "summary": "List organizations",
+        "operationId": "organizations_query",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "List organizations",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Organization"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BAD_REQUEST"
+          },
+          "403": {
+            "$ref": "#/components/responses/FORBIDDEN"
+          },
+          "404": {
+            "$ref": "#/components/responses/NOT_FOUND"
+          },
+          "409": {
+            "$ref": "#/components/responses/CONFLICT"
+          },
+          "500": {
+            "$ref": "#/components/responses/INTERNAL_SERVER_ERROR"
+          },
+          "default": {
+            "$ref": "#/components/responses/UNEXPECTED_ERROR"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "organizations"
+        ],
+        "description": "Create a new organization",
+        "summary": "Create a new organization",
+        "operationId": "createOrganization_mutation",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {}
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Create a new organization",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Organization"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BAD_REQUEST"
+          },
+          "403": {
+            "$ref": "#/components/responses/FORBIDDEN"
+          },
+          "404": {
+            "$ref": "#/components/responses/NOT_FOUND"
+          },
+          "409": {
+            "$ref": "#/components/responses/CONFLICT"
+          },
+          "500": {
+            "$ref": "#/components/responses/INTERNAL_SERVER_ERROR"
+          },
+          "default": {
+            "$ref": "#/components/responses/UNEXPECTED_ERROR"
+          }
+        }
+      }
+    },
+    "/organizations/{id}": {
+      "get": {
+        "tags": [
+          "organizations"
+        ],
+        "description": "Get organization",
+        "summary": "Get organization",
+        "operationId": "organization_query",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Get organization",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Organization"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BAD_REQUEST"
+          },
+          "403": {
+            "$ref": "#/components/responses/FORBIDDEN"
+          },
+          "404": {
+            "$ref": "#/components/responses/NOT_FOUND"
+          },
+          "409": {
+            "$ref": "#/components/responses/CONFLICT"
+          },
+          "500": {
+            "$ref": "#/components/responses/INTERNAL_SERVER_ERROR"
+          },
+          "default": {
+            "$ref": "#/components/responses/UNEXPECTED_ERROR"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "organizations"
+        ],
+        "description": "Update organization",
+        "summary": "Update organization",
+        "operationId": "updateOrganization_mutation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "imageURL": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Update organization",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Organization"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BAD_REQUEST"
+          },
+          "403": {
+            "$ref": "#/components/responses/FORBIDDEN"
+          },
+          "404": {
+            "$ref": "#/components/responses/NOT_FOUND"
+          },
+          "409": {
+            "$ref": "#/components/responses/CONFLICT"
+          },
+          "500": {
+            "$ref": "#/components/responses/INTERNAL_SERVER_ERROR"
+          },
+          "default": {
+            "$ref": "#/components/responses/UNEXPECTED_ERROR"
+          }
+        }
+      }
+    },
+    "/services/{id}": {
+      "get": {
+        "tags": [
+          "services"
+        ],
+        "description": "Get service",
+        "summary": "Get service",
+        "operationId": "service_query",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Get service",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Service"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BAD_REQUEST"
+          },
+          "403": {
+            "$ref": "#/components/responses/FORBIDDEN"
+          },
+          "404": {
+            "$ref": "#/components/responses/NOT_FOUND"
+          },
+          "409": {
+            "$ref": "#/components/responses/CONFLICT"
+          },
+          "500": {
+            "$ref": "#/components/responses/INTERNAL_SERVER_ERROR"
+          },
+          "default": {
+            "$ref": "#/components/responses/UNEXPECTED_ERROR"
+          }
+        }
+      }
+    },
+    "/services": {
+      "get": {
+        "tags": [
+          "services"
+        ],
+        "description": "List services",
+        "summary": "List services",
+        "operationId": "services_query",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "environmentId",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "namespaceId",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "name",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List services",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Service"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BAD_REQUEST"
+          },
+          "403": {
+            "$ref": "#/components/responses/FORBIDDEN"
+          },
+          "404": {
+            "$ref": "#/components/responses/NOT_FOUND"
+          },
+          "409": {
+            "$ref": "#/components/responses/CONFLICT"
+          },
+          "500": {
+            "$ref": "#/components/responses/INTERNAL_SERVER_ERROR"
+          },
+          "default": {
+            "$ref": "#/components/responses/UNEXPECTED_ERROR"
+          }
+        }
+      }
+    },
+    "/service": {
+      "get": {
+        "tags": [
+          "services"
+        ],
+        "description": "Get service by filters",
+        "summary": "Get service by filters",
+        "operationId": "oneService_query",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "environmentId",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "namespaceId",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "name",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Get service by filters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Service"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BAD_REQUEST"
+          },
+          "403": {
+            "$ref": "#/components/responses/FORBIDDEN"
+          },
+          "404": {
+            "$ref": "#/components/responses/NOT_FOUND"
+          },
+          "409": {
+            "$ref": "#/components/responses/CONFLICT"
+          },
+          "500": {
+            "$ref": "#/components/responses/INTERNAL_SERVER_ERROR"
+          },
+          "default": {
+            "$ref": "#/components/responses/UNEXPECTED_ERROR"
+          }
+        }
+      }
+    },
+    "/users": {
+      "get": {
+        "tags": [
+          "users"
+        ],
+        "description": "List users",
+        "summary": "List users",
+        "operationId": "users_query",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "List users",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/User"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BAD_REQUEST"
+          },
+          "403": {
+            "$ref": "#/components/responses/FORBIDDEN"
+          },
+          "404": {
+            "$ref": "#/components/responses/NOT_FOUND"
+          },
+          "409": {
+            "$ref": "#/components/responses/CONFLICT"
+          },
+          "500": {
+            "$ref": "#/components/responses/INTERNAL_SERVER_ERROR"
+          },
+          "default": {
+            "$ref": "#/components/responses/UNEXPECTED_ERROR"
+          }
+        }
+      }
+    },
+    "/users/{id}": {
+      "get": {
+        "tags": [
+          "users"
+        ],
+        "description": "Get user",
+        "summary": "Get user",
+        "operationId": "user_query",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Get user",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BAD_REQUEST"
+          },
+          "403": {
+            "$ref": "#/components/responses/FORBIDDEN"
+          },
+          "404": {
+            "$ref": "#/components/responses/NOT_FOUND"
+          },
+          "409": {
+            "$ref": "#/components/responses/CONFLICT"
+          },
+          "500": {
+            "$ref": "#/components/responses/INTERNAL_SERVER_ERROR"
+          },
+          "default": {
+            "$ref": "#/components/responses/UNEXPECTED_ERROR"
+          }
+        }
+      }
+    },
+    "/environments/{id}/labels": {
+      "post": {
+        "tags": [
+          "environments"
+        ],
+        "description": "Add labels to environment",
+        "summary": "Add labels to environment",
+        "operationId": "addEnvironmentLabel_mutation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "label": {
+                    "$ref": "#/components/schemas/LabelInput"
+                  }
+                },
+                "required": [
+                  "label"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Add labels to environment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Environment"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BAD_REQUEST"
+          },
+          "403": {
+            "$ref": "#/components/responses/FORBIDDEN"
+          },
+          "404": {
+            "$ref": "#/components/responses/NOT_FOUND"
+          },
+          "409": {
+            "$ref": "#/components/responses/CONFLICT"
+          },
+          "500": {
+            "$ref": "#/components/responses/INTERNAL_SERVER_ERROR"
+          },
+          "default": {
+            "$ref": "#/components/responses/UNEXPECTED_ERROR"
+          }
+        }
+      }
+    },
+    "/environments/{id}/labels/:key": {
+      "delete": {
+        "tags": [
+          "environments"
+        ],
+        "description": "Remove labels from environment",
+        "summary": "Remove labels from environment",
+        "operationId": "deleteEnvironmentLabel_mutation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "key",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Remove labels from environment",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Environment"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BAD_REQUEST"
+          },
+          "403": {
+            "$ref": "#/components/responses/FORBIDDEN"
+          },
+          "404": {
+            "$ref": "#/components/responses/NOT_FOUND"
+          },
+          "409": {
+            "$ref": "#/components/responses/CONFLICT"
+          },
+          "500": {
+            "$ref": "#/components/responses/INTERNAL_SERVER_ERROR"
+          },
+          "default": {
+            "$ref": "#/components/responses/UNEXPECTED_ERROR"
+          }
+        }
+      }
+    },
+    "/integrations/generic": {
+      "post": {
+        "tags": [
+          "integrations"
+        ],
+        "description": "Create a new generic integration",
+        "summary": "Create a new generic integration",
+        "operationId": "createGenericIntegration_mutation",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Create a new generic integration",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Integration"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BAD_REQUEST"
+          },
+          "403": {
+            "$ref": "#/components/responses/FORBIDDEN"
+          },
+          "404": {
+            "$ref": "#/components/responses/NOT_FOUND"
+          },
+          "409": {
+            "$ref": "#/components/responses/CONFLICT"
+          },
+          "500": {
+            "$ref": "#/components/responses/INTERNAL_SERVER_ERROR"
+          },
+          "default": {
+            "$ref": "#/components/responses/UNEXPECTED_ERROR"
+          }
+        }
+      }
+    },
+    "/integrations/kubernetes": {
+      "post": {
+        "tags": [
+          "integrations"
+        ],
+        "description": "Create a new Kubernetes integration",
+        "summary": "Create a new Kubernetes integration",
+        "operationId": "createKubernetesIntegration_mutation",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "environmentId": {
+                    "type": "string"
+                  },
+                  "clusterId": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "clusterId"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Create a new Kubernetes integration",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Integration"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BAD_REQUEST"
+          },
+          "403": {
+            "$ref": "#/components/responses/FORBIDDEN"
+          },
+          "404": {
+            "$ref": "#/components/responses/NOT_FOUND"
+          },
+          "409": {
+            "$ref": "#/components/responses/CONFLICT"
+          },
+          "500": {
+            "$ref": "#/components/responses/INTERNAL_SERVER_ERROR"
+          },
+          "default": {
+            "$ref": "#/components/responses/UNEXPECTED_ERROR"
+          }
+        }
+      }
+    },
+    "/invites/{id}/accept": {
+      "patch": {
+        "tags": [
+          "invites"
+        ],
+        "description": "Accept user invite",
+        "summary": "Accept user invite",
+        "operationId": "acceptInvite_mutation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {}
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Accept user invite",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Invite"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BAD_REQUEST"
+          },
+          "403": {
+            "$ref": "#/components/responses/FORBIDDEN"
+          },
+          "404": {
+            "$ref": "#/components/responses/NOT_FOUND"
+          },
+          "409": {
+            "$ref": "#/components/responses/CONFLICT"
+          },
+          "500": {
+            "$ref": "#/components/responses/INTERNAL_SERVER_ERROR"
+          },
+          "default": {
+            "$ref": "#/components/responses/UNEXPECTED_ERROR"
+          }
+        }
+      }
+    },
+    "/organizations/{id}/users/:user_id": {
+      "delete": {
+        "tags": [
+          "organizations"
+        ],
+        "description": "Remove user from organization",
+        "summary": "Remove user from organization",
+        "operationId": "disassociateUserFromOrganization_mutation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "userId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Remove user from organization",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BAD_REQUEST"
+          },
+          "403": {
+            "$ref": "#/components/responses/FORBIDDEN"
+          },
+          "404": {
+            "$ref": "#/components/responses/NOT_FOUND"
+          },
+          "409": {
+            "$ref": "#/components/responses/CONFLICT"
+          },
+          "500": {
+            "$ref": "#/components/responses/INTERNAL_SERVER_ERROR"
+          },
+          "default": {
+            "$ref": "#/components/responses/UNEXPECTED_ERROR"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT"
+      },
+      "organizationHeader": {
+        "type": "apiKey",
+        "in": "header",
+        "description": "Selected organization ID. Leave blank to auto-select the first organization for the current user.",
+        "name": "X-Otterize-Organization"
+      }
+    },
+    "responses": {
+      "UNEXPECTED_ERROR": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
+      "NOT_FOUND": {
+        "description": "Not Found",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
+      "INTERNAL_SERVER_ERROR": {
+        "description": "Internal Server Error",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
+      "BAD_REQUEST": {
+        "description": "Bad Request",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
+      "FORBIDDEN": {
+        "description": "Forbidden",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
+      "CONFLICT": {
+        "description": "Conflict",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "InputAccessGraphFilter": {
+        "type": "object",
+        "properties": {
+          "environmentIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "clusterIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "serviceIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "namespaceIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "lastSeenAfter": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "includeServicesWithNoEdges": {
+            "type": "boolean"
+          }
+        }
+      },
+      "AccessGraphFilter": {
+        "type": "object",
+        "properties": {
+          "environmentIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "clusterIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "namespaceIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "serviceIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "lastSeenAfter": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "includeServicesWithNoEdges": {
+            "type": "boolean"
+          }
+        }
+      },
+      "AccessGraph": {
+        "type": "object",
+        "required": [
+          "filter",
+          "clusters",
+          "serviceAccessGraphs"
+        ],
+        "properties": {
+          "filter": {
+            "$ref": "#/components/schemas/AccessGraphFilter"
+          },
+          "clusters": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "id"
+              ],
+              "properties": {
+                "id": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "serviceAccessGraphs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ServiceAccessGraph"
+            }
+          }
+        }
+      },
+      "EdgeAccessStatus": {
+        "type": "object",
+        "required": [
+          "useNetworkPoliciesInAccessGraphStates",
+          "verdict",
+          "reason"
+        ],
+        "properties": {
+          "useNetworkPoliciesInAccessGraphStates": {
+            "type": "boolean"
+          },
+          "verdict": {
+            "type": "string",
+            "enum": [
+              "EXPLICITLY_ALLOWED",
+              "IMPLICITLY_ALLOWED",
+              "WOULD_BE_BLOCKED",
+              "BLOCKED",
+              "UNKNOWN"
+            ]
+          },
+          "reason": {
+            "type": "string",
+            "enum": [
+              "ALLOWED_BY_APPLIED_INTENTS",
+              "ALLOWED_BY_APPLIED_INTENTS_OVERLY_PERMISSIVE",
+              "BLOCKED_BY_DEFAULT_DENY",
+              "INTENTS_OPERATOR_NOT_ENFORCING",
+              "INTENTS_OPERATOR_NOT_ENFORCING_MISSING_APPLIED_INTENT",
+              "MISSING_APPLIED_INTENT",
+              "INTENTS_OPERATOR_NEVER_CONNECTED",
+              "NETWORK_MAPPER_NEVER_CONNECTED"
+            ]
+          }
+        }
+      },
+      "ServerProtectionStatus": {
+        "type": "object",
+        "required": [
+          "verdict",
+          "reason"
+        ],
+        "properties": {
+          "verdict": {
+            "type": "string",
+            "enum": [
+              "UNKNOWN",
+              "UNPROTECTED",
+              "PROTECTED"
+            ]
+          },
+          "reason": {
+            "type": "string",
+            "enum": [
+              "INTENTS_OPERATOR_NEVER_CONNECTED",
+              "INTENTS_OPERATOR_NOT_ENFORCING",
+              "SERVER_HAS_NO_NETWORK_POLICY",
+              "PROTECTED_BY_DEFAULT_DENY",
+              "PROTECTED_BY_SERVER_NETWORK_POLICY"
+            ]
+          }
+        }
+      },
+      "ServerBlockingStatus": {
+        "type": "object",
+        "required": [
+          "verdict",
+          "reason"
+        ],
+        "properties": {
+          "verdict": {
+            "type": "string",
+            "enum": [
+              "UNKNOWN",
+              "NOT_BLOCKING",
+              "WOULD_BLOCK",
+              "BLOCKING"
+            ]
+          },
+          "reason": {
+            "type": "string",
+            "enum": [
+              "INTENTS_OPERATOR_NEVER_CONNECTED",
+              "NETWORK_MAPPER_NEVER_CONNECTED",
+              "INTENTS_IMPLICITLY_ALLOWED",
+              "ALL_INTENTS_APPLIED",
+              "MISSING_APPLIED_INTENTS",
+              "INTENTS_OPERATOR_NOT_ENFORCING"
+            ]
+          }
+        }
+      },
+      "ServiceAccessStatus": {
+        "type": "object",
+        "required": [
+          "useNetworkPoliciesInAccessGraphStates",
+          "protectionStatus",
+          "blockingStatus"
+        ],
+        "properties": {
+          "useNetworkPoliciesInAccessGraphStates": {
+            "type": "boolean"
+          },
+          "protectionStatus": {
+            "$ref": "#/components/schemas/ServerProtectionStatus"
+          },
+          "blockingStatus": {
+            "$ref": "#/components/schemas/ServerBlockingStatus"
+          }
+        }
+      },
+      "ServiceAccessGraph": {
+        "type": "object",
+        "required": [
+          "service",
+          "accessStatus",
+          "calls",
+          "serves"
+        ],
+        "properties": {
+          "service": {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "type": "string"
+              }
+            }
+          },
+          "accessStatus": {
+            "$ref": "#/components/schemas/ServiceAccessStatus"
+          },
+          "calls": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AccessGraphEdge"
+            }
+          },
+          "serves": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AccessGraphEdge"
+            }
+          }
+        }
+      },
+      "AccessGraphEdge": {
+        "type": "object",
+        "required": [
+          "client",
+          "server",
+          "discoveredIntents",
+          "appliedIntents",
+          "accessStatus"
+        ],
+        "properties": {
+          "client": {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "type": "string"
+              }
+            }
+          },
+          "server": {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "type": "string"
+              }
+            }
+          },
+          "discoveredIntents": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "id"
+              ],
+              "properties": {
+                "id": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "appliedIntents": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "id"
+              ],
+              "properties": {
+                "id": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "accessStatus": {
+            "$ref": "#/components/schemas/EdgeAccessStatus"
+          }
+        }
+      },
+      "ClusterConfiguration": {
+        "type": "object",
+        "required": [
+          "globalDefaultDeny",
+          "useNetworkPoliciesInAccessGraphStates"
+        ],
+        "properties": {
+          "globalDefaultDeny": {
+            "type": "boolean"
+          },
+          "useNetworkPoliciesInAccessGraphStates": {
+            "type": "boolean"
+          }
+        }
+      },
+      "ClusterConfigurationInput": {
+        "type": "object",
+        "required": [
+          "globalDefaultDeny",
+          "useNetworkPoliciesInAccessGraphStates"
+        ],
+        "properties": {
+          "globalDefaultDeny": {
+            "type": "boolean"
+          },
+          "useNetworkPoliciesInAccessGraphStates": {
+            "type": "boolean"
+          }
+        }
+      },
+      "Cluster": {
+        "type": "object",
+        "required": [
+          "name",
+          "components",
+          "namespaces",
+          "serviceCount",
+          "defaultEnvironment",
+          "id"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "NEVER_CONNECTED",
+              "DISCONNECTED",
+              "PARTIALLY_CONNECTED",
+              "CONNECTED"
+            ]
+          },
+          "components": {
+            "$ref": "#/components/schemas/IntegrationComponents"
+          },
+          "configuration": {
+            "$ref": "#/components/schemas/ClusterConfiguration"
+          },
+          "namespaces": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "id"
+              ],
+              "properties": {
+                "id": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "serviceCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "integration": {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "type": "string"
+              }
+            }
+          },
+          "defaultEnvironment": {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "type": "string"
+              }
+            }
+          },
+          "id": {
+            "type": "string"
+          }
+        }
+      },
+      "Service": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "environment"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "namespace": {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "type": "string"
+              }
+            }
+          },
+          "environment": {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "type": "string"
+              }
+            }
+          },
+          "kafkaServerConfig": {
+            "$ref": "#/components/schemas/KafkaServerConfig",
+            "description": "If service is Kafka, its KafkaServerConfig."
+          },
+          "certificateInformation": {
+            "$ref": "#/components/schemas/CertificateInformation"
+          }
+        }
+      },
+      "CertificateInformation": {
+        "type": "object",
+        "required": [
+          "commonName"
+        ],
+        "properties": {
+          "commonName": {
+            "type": "string"
+          },
+          "dnsNames": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "ttl": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "LabelInput": {
+        "type": "object",
+        "required": [
+          "key"
+        ],
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        }
+      },
+      "Label": {
+        "type": "object",
+        "required": [
+          "key"
+        ],
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
+        }
+      },
+      "Environment": {
+        "type": "object",
+        "required": [
+          "namespaces",
+          "serviceCount",
+          "appliedIntentsCount",
+          "id"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "labels": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Label"
+            }
+          },
+          "namespaces": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "id"
+              ],
+              "properties": {
+                "id": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "serviceCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "appliedIntentsCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "id": {
+            "type": "string"
+          }
+        }
+      },
+      "Integration": {
+        "type": "object",
+        "required": [
+          "name",
+          "type",
+          "credentials",
+          "id"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "GENERIC",
+              "KUBERNETES"
+            ]
+          },
+          "credentials": {
+            "$ref": "#/components/schemas/IntegrationCredentials"
+          },
+          "components": {
+            "$ref": "#/components/schemas/IntegrationComponents"
+          },
+          "defaultEnvironment": {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "type": "string"
+              }
+            }
+          },
+          "cluster": {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "type": "string"
+              }
+            }
+          },
+          "id": {
+            "type": "string"
+          }
+        }
+      },
+      "IntegrationCredentials": {
+        "type": "object",
+        "required": [
+          "clientId",
+          "clientSecret"
+        ],
+        "properties": {
+          "clientId": {
+            "type": "string"
+          },
+          "clientSecret": {
+            "type": "string"
+          }
+        }
+      },
+      "ComponentStatus": {
+        "type": "object",
+        "required": [
+          "type"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "NOT_INTEGRATED",
+              "CONNECTED",
+              "DISCONNECTED"
+            ]
+          },
+          "lastSeen": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "IntentsOperatorComponent": {
+        "type": "object",
+        "required": [
+          "status",
+          "type"
+        ],
+        "properties": {
+          "status": {
+            "$ref": "#/components/schemas/ComponentStatus"
+          },
+          "configuration": {
+            "$ref": "#/components/schemas/IntentsOperatorConfiguration"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "INTENTS_OPERATOR",
+              "CREDENTIALS_OPERATOR",
+              "NETWORK_MAPPER"
+            ]
+          }
+        }
+      },
+      "CredentialsOperatorComponent": {
+        "type": "object",
+        "required": [
+          "status",
+          "type"
+        ],
+        "properties": {
+          "status": {
+            "$ref": "#/components/schemas/ComponentStatus"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "INTENTS_OPERATOR",
+              "CREDENTIALS_OPERATOR",
+              "NETWORK_MAPPER"
+            ]
+          }
+        }
+      },
+      "NetworkMapperComponent": {
+        "type": "object",
+        "required": [
+          "status",
+          "type"
+        ],
+        "properties": {
+          "status": {
+            "$ref": "#/components/schemas/ComponentStatus"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "INTENTS_OPERATOR",
+              "CREDENTIALS_OPERATOR",
+              "NETWORK_MAPPER"
+            ]
+          }
+        }
+      },
+      "IntentsOperatorConfiguration": {
+        "type": "object",
+        "required": [
+          "enableEnforcement"
+        ],
+        "properties": {
+          "enableEnforcement": {
+            "type": "boolean"
+          }
+        }
+      },
+      "IntegrationComponents": {
+        "type": "object",
+        "required": [
+          "intentsOperator",
+          "credentialsOperator",
+          "networkMapper",
+          "clusterId"
+        ],
+        "properties": {
+          "intentsOperator": {
+            "$ref": "#/components/schemas/IntentsOperatorComponent"
+          },
+          "credentialsOperator": {
+            "$ref": "#/components/schemas/CredentialsOperatorComponent"
+          },
+          "networkMapper": {
+            "$ref": "#/components/schemas/NetworkMapperComponent"
+          },
+          "clusterId": {
+            "type": "string"
+          }
+        }
+      },
+      "Intent": {
+        "type": "object",
+        "required": [
+          "id",
+          "server",
+          "client"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "server": {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "type": "string"
+              }
+            }
+          },
+          "client": {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "type": "string"
+              }
+            }
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "HTTP",
+              "KAFKA"
+            ]
+          },
+          "kafkaResources": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/KafkaConfig"
+            }
+          },
+          "httpResources": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/HTTPConfig"
+            }
+          }
+        }
+      },
+      "KafkaConfig": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "operations": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "ALL",
+                "CONSUME",
+                "PRODUCE",
+                "CREATE",
+                "ALTER",
+                "DELETE",
+                "DESCRIBE",
+                "CLUSTER_ACTION",
+                "DESCRIBE_CONFIGS",
+                "ALTER_CONFIGS",
+                "IDEMPOTENT_WRITE"
+              ]
+            }
+          }
+        }
+      },
+      "HTTPConfig": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string"
+          },
+          "method": {
+            "type": "string",
+            "enum": [
+              "GET",
+              "POST",
+              "PUT",
+              "DELETE",
+              "OPTIONS",
+              "TRACE",
+              "PATCH",
+              "CONNECT"
+            ]
+          }
+        }
+      },
+      "Invite": {
+        "type": "object",
+        "required": [
+          "id",
+          "email",
+          "organization",
+          "inviter",
+          "created",
+          "status"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "organization": {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "type": "string"
+              }
+            }
+          },
+          "inviter": {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "type": "string"
+              }
+            }
+          },
+          "created": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "acceptedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "PENDING",
+              "ACCEPTED"
+            ]
+          }
+        }
+      },
+      "KafkaServerConfig": {
+        "type": "object",
+        "required": [
+          "topics"
+        ],
+        "properties": {
+          "address": {
+            "type": "string"
+          },
+          "topics": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/KafkaTopic"
+            }
+          }
+        }
+      },
+      "KafkaTopic": {
+        "type": "object",
+        "required": [
+          "clientIdentityRequired",
+          "intentsRequired",
+          "pattern",
+          "topic"
+        ],
+        "properties": {
+          "clientIdentityRequired": {
+            "type": "boolean"
+          },
+          "intentsRequired": {
+            "type": "boolean"
+          },
+          "pattern": {
+            "type": "string",
+            "enum": [
+              "LITERAL",
+              "PREFIX"
+            ]
+          },
+          "topic": {
+            "type": "string"
+          }
+        }
+      },
+      "Me": {
+        "type": "object",
+        "required": [
+          "user",
+          "organizations",
+          "invites"
+        ],
+        "properties": {
+          "user": {
+            "$ref": "#/components/schemas/User",
+            "description": "The logged-in user details."
+          },
+          "organizations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Organization"
+            }
+          },
+          "invites": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Invite"
+            }
+          }
+        }
+      },
+      "Namespace": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "services"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "cluster": {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "type": "string"
+              }
+            }
+          },
+          "environment": {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "type": "string"
+              }
+            }
+          },
+          "services": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "id"
+              ],
+              "properties": {
+                "id": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "Organization": {
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "imageURL": {
+            "type": "string"
+          }
+        }
+      },
+      "User": {
+        "type": "object",
+        "required": [
+          "id",
+          "email",
+          "name",
+          "imageURL",
+          "authProviderUserId"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "imageURL": {
+            "type": "string"
+          },
+          "authProviderUserId": {
+            "type": "string"
+          }
+        }
+      },
+      "Error": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "message"
+        ]
+      }
+    }
+  },
+  "security": [
+    {
+      "bearerAuth": [],
+      "organizationHeader": []
+    }
+  ]
+}

--- a/src/pkg/cloudclient/restapi/cloudapi/openapi.json
+++ b/src/pkg/cloudclient/restapi/cloudapi/openapi.json
@@ -1017,14 +1017,6 @@
             "schema": {
               "type": "string"
             }
-          },
-          {
-            "in": "query",
-            "name": "source",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
           }
         ],
         "responses": {
@@ -3284,7 +3276,7 @@
               "KAFKA"
             ]
           },
-          "kafkaResources": {
+          "kafkaTopics": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/KafkaConfig"
@@ -3334,18 +3326,21 @@
           "path": {
             "type": "string"
           },
-          "method": {
-            "type": "string",
-            "enum": [
-              "GET",
-              "POST",
-              "PUT",
-              "DELETE",
-              "OPTIONS",
-              "TRACE",
-              "PATCH",
-              "CONNECT"
-            ]
+          "methods": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "GET",
+                "POST",
+                "PUT",
+                "DELETE",
+                "OPTIONS",
+                "TRACE",
+                "PATCH",
+                "CONNECT"
+              ]
+            }
           }
         }
       },

--- a/src/pkg/cloudclient/restapi/cloudapi/openapi.json
+++ b/src/pkg/cloudclient/restapi/cloudapi/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Otterize API Server",
     "version": "v1beta",
-    "x-version-hash": "53e5f92f2621fc2187babaeaa811469691e58bcf"
+    "x-revision": "91efb6f8acb98985fc2b993baa8d279049c8b302"
   },
   "servers": [
     {

--- a/src/pkg/cloudclient/restapi/cloudapi/openapi.json
+++ b/src/pkg/cloudclient/restapi/cloudapi/openapi.json
@@ -2,7 +2,8 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Otterize API Server",
-    "version": "6ec4575de806fb55ec4aa2cab95e94debffacc67"
+    "version": "v1beta",
+    "x-version-hash": "53e5f92f2621fc2187babaeaa811469691e58bcf"
   },
   "servers": [
     {

--- a/src/pkg/cloudclient/restapi/generate.go
+++ b/src/pkg/cloudclient/restapi/generate.go
@@ -1,3 +1,4 @@
 package restapi
 
-//go:generate go run github.com/deepmap/oapi-codegen/cmd/oapi-codegen --package=cloudapi -generate=types,client -o ./cloudapi/api.gen.go http://local.otterize.com:4000/api/openapi.json
+//go:generate curl -q http://local.otterize.com:4000/api/openapi.json -o ./cloudapi/openapi.json
+//go:generate go run github.com/deepmap/oapi-codegen/cmd/oapi-codegen -o ./cloudapi/api.gen.go --package=cloudapi -generate=types,client ./cloudapi/openapi.json

--- a/src/pkg/cloudclient/restapi/generate.go
+++ b/src/pkg/cloudclient/restapi/generate.go
@@ -1,4 +1,4 @@
 package restapi
 
-//go:generate curl -q http://local.otterize.com:4000/api/openapi.json -o ./cloudapi/openapi.json
+//go:generate curl -s http://local.otterize.com:4000/api/openapi.json -o ./cloudapi/openapi.json
 //go:generate go run github.com/deepmap/oapi-codegen/cmd/oapi-codegen -o ./cloudapi/api.gen.go --package=cloudapi -generate=types,client ./cloudapi/openapi.json

--- a/src/pkg/cloudclient/restapi/version.go
+++ b/src/pkg/cloudclient/restapi/version.go
@@ -3,10 +3,13 @@ package restapi
 import (
 	_ "embed"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"github.com/deepmap/oapi-codegen/pkg/util"
 	"github.com/getkin/kin-openapi/openapi3"
+)
+
+const (
+	ApiVersionHashExt = "x-version-hash2"
 )
 
 type APIVersion struct {
@@ -39,9 +42,9 @@ func GetLocalApiVersion() (APIVersion, error) {
 func extractVersionInfo(apiSpecs *openapi3.T) (APIVersion, error) {
 	version := apiSpecs.Info.Version
 
-	versionHashExt, ok := apiSpecs.Info.Extensions["x-version-hash"]
+	versionHashExt, ok := apiSpecs.Info.Extensions[ApiVersionHashExt]
 	if !ok {
-		return APIVersion{}, errors.New("failed extracting version hash: API specs missing x-version-hash extension")
+		return APIVersion{}, fmt.Errorf("failed extracting version hash: API specs missing %s extension", ApiVersionHashExt)
 	}
 
 	var versionHashValue string

--- a/src/pkg/cloudclient/restapi/version.go
+++ b/src/pkg/cloudclient/restapi/version.go
@@ -1,0 +1,29 @@
+package restapi
+
+import (
+	_ "embed"
+	"github.com/deepmap/oapi-codegen/pkg/util"
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+//go:embed cloudapi/openapi.json
+var openapispecs []byte
+
+func GetCloudApiVersion(apiUrl string) (string, error) {
+	apiSpecs, err := util.LoadSwagger(apiUrl + "/openapi.json")
+	if err != nil {
+		return "", err
+	}
+
+	return apiSpecs.Info.Version, nil
+}
+
+func GetLocalApiVersion() (string, error) {
+	loader := openapi3.NewLoader()
+	apiSpecs, err := loader.LoadFromData(openapispecs)
+	if err != nil {
+		return "", err
+	}
+
+	return apiSpecs.Info.Version, nil
+}

--- a/src/pkg/cloudclient/restapi/version.go
+++ b/src/pkg/cloudclient/restapi/version.go
@@ -9,12 +9,12 @@ import (
 )
 
 const (
-	ApiVersionHashExt = "x-revision-hash"
+	ApiRevisionExt = "x-revision"
 )
 
 type APIVersion struct {
-	Version string
-	Hash    string
+	Version  string
+	Revision string
 }
 
 //go:embed cloudapi/openapi.json
@@ -42,18 +42,18 @@ func GetLocalApiVersion() (APIVersion, error) {
 func extractVersionInfo(apiSpecs *openapi3.T) (APIVersion, error) {
 	version := apiSpecs.Info.Version
 
-	versionHashExt, ok := apiSpecs.Info.Extensions[ApiVersionHashExt]
+	revisionExt, ok := apiSpecs.Info.Extensions[ApiRevisionExt]
 	if !ok {
-		return APIVersion{}, fmt.Errorf("failed extracting version hash: API specs missing %s extension", ApiVersionHashExt)
+		return APIVersion{}, fmt.Errorf("failed extracting API revision: API specs missing %s extension", ApiRevisionExt)
 	}
 
-	var versionHashValue string
-	if err := json.Unmarshal(versionHashExt.(json.RawMessage), &versionHashValue); err != nil {
-		return APIVersion{}, fmt.Errorf("failed extracting version hash: %w", err)
+	var revisionValue string
+	if err := json.Unmarshal(revisionExt.(json.RawMessage), &revisionValue); err != nil {
+		return APIVersion{}, fmt.Errorf("failed extracting API revision: %w", err)
 	}
 
 	return APIVersion{
-		Version: version,
-		Hash:    versionHashValue,
+		Version:  version,
+		Revision: revisionValue,
 	}, nil
 }

--- a/src/pkg/cloudclient/restapi/version.go
+++ b/src/pkg/cloudclient/restapi/version.go
@@ -2,28 +2,55 @@ package restapi
 
 import (
 	_ "embed"
+	"encoding/json"
+	"errors"
+	"fmt"
 	"github.com/deepmap/oapi-codegen/pkg/util"
 	"github.com/getkin/kin-openapi/openapi3"
 )
 
+type APIVersion struct {
+	Version string
+	Hash    string
+}
+
 //go:embed cloudapi/openapi.json
 var openapispecs []byte
 
-func GetCloudApiVersion(apiUrl string) (string, error) {
+func GetCloudApiVersion(apiUrl string) (APIVersion, error) {
 	apiSpecs, err := util.LoadSwagger(apiUrl + "/openapi.json")
 	if err != nil {
-		return "", err
+		return APIVersion{}, err
 	}
 
-	return apiSpecs.Info.Version, nil
+	return extractVersionInfo(apiSpecs)
 }
 
-func GetLocalApiVersion() (string, error) {
+func GetLocalApiVersion() (APIVersion, error) {
 	loader := openapi3.NewLoader()
 	apiSpecs, err := loader.LoadFromData(openapispecs)
 	if err != nil {
-		return "", err
+		return APIVersion{}, err
 	}
 
-	return apiSpecs.Info.Version, nil
+	return extractVersionInfo(apiSpecs)
+}
+
+func extractVersionInfo(apiSpecs *openapi3.T) (APIVersion, error) {
+	version := apiSpecs.Info.Version
+
+	versionHashExt, ok := apiSpecs.Info.Extensions["x-version-hash"]
+	if !ok {
+		return APIVersion{}, errors.New("failed extracting version hash: API specs missing x-version-hash extension")
+	}
+
+	var versionHashValue string
+	if err := json.Unmarshal(versionHashExt.(json.RawMessage), &versionHashValue); err != nil {
+		return APIVersion{}, fmt.Errorf("failed extracting version hash: unexpected value %v", versionHashExt)
+	}
+
+	return APIVersion{
+		Version: version,
+		Hash:    versionHashValue,
+	}, nil
 }

--- a/src/pkg/cloudclient/restapi/version.go
+++ b/src/pkg/cloudclient/restapi/version.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	ApiVersionHashExt = "x-version-hash2"
+	ApiVersionHashExt = "x-revision-hash"
 )
 
 type APIVersion struct {
@@ -49,7 +49,7 @@ func extractVersionInfo(apiSpecs *openapi3.T) (APIVersion, error) {
 
 	var versionHashValue string
 	if err := json.Unmarshal(versionHashExt.(json.RawMessage), &versionHashValue); err != nil {
-		return APIVersion{}, fmt.Errorf("failed extracting version hash: unexpected value %v", versionHashExt)
+		return APIVersion{}, fmt.Errorf("failed extracting version hash: %w", err)
 	}
 
 	return APIVersion{


### PR DESCRIPTION
* add `otterize api-version` cmd that reads the openapi specs version from otterize cloud, and prints it to the screen or formats it as a go file in the given path+package
* use `otterize api-version` in codegen process to store the API version along with the compiled API specs
* compare cloud API version and compiled API version when initializing cloud clients and issue a warning in case of mismatch. 

https://www.notion.so/otterize/API-versioning-changes-dfdf7364fff04e69ba70a47919ea306f