### PR TITLE
Print helpful message when no connections found

### DIFF
--- a/src/cmd/mapper/mapper-list.go
+++ b/src/cmd/mapper/mapper-list.go
@@ -31,6 +31,10 @@ var ListCmd = &cobra.Command{
 				}
 
 			}
+
+			if len(servicesIntents) == 0 {
+				output.PrintStderr("No connections found. The network mapper detects (1) connections that are currently open and (2) DNS lookups while a connection is being initiated, for connections between pods on this cluster.")
+			}
 			return nil
 		})
 	},


### PR DESCRIPTION
In https://github.com/otterize/network-mapper/issues/63, undera used the CLI and did not receive output because there was no traffic detected. This change outputs a helpful message in this case, that explains when traffic is detected.