### PR TITLE
K8s integration auto-generates name from cluster name

### DIFF
--- a/src/cmd/integrations/create/create-kubernetes-integration.go
+++ b/src/cmd/integrations/create/create-kubernetes-integration.go
@@ -25,13 +25,11 @@ var CreateKubernetesIntegrationCmd = &cobra.Command{
 			return err
 		}
 
-		name := viper.GetString(NameKey)
 		environmentID := viper.GetString(EnvironmentIDKey)
 		clusterID := viper.GetString(ClusterIDKey)
 
 		r, err := c.CreateKubernetesIntegrationMutationWithResponse(ctxTimeout,
 			cloudapi.CreateKubernetesIntegrationMutationJSONRequestBody{
-				Name:          name,
 				EnvironmentId: lo.Ternary(environmentID == "", nil, &environmentID),
 				ClusterId:     clusterID,
 			})
@@ -51,8 +49,6 @@ var CreateKubernetesIntegrationCmd = &cobra.Command{
 }
 
 func init() {
-	CreateKubernetesIntegrationCmd.Flags().StringP(NameKey, NameShorthand, "", "integration name")
-	cobra.CheckErr(CreateKubernetesIntegrationCmd.MarkFlagRequired(NameKey))
 	CreateKubernetesIntegrationCmd.Flags().String(EnvironmentIDKey, "", "default environment id")
 	CreateKubernetesIntegrationCmd.Flags().String(ClusterIDKey, "", "cluster id")
 	cobra.CheckErr(CreateKubernetesIntegrationCmd.MarkFlagRequired(ClusterIDKey))

--- a/src/pkg/cloudclient/restapi/cloudapi/api.gen.go
+++ b/src/pkg/cloudclient/restapi/cloudapi/api.gen.go
@@ -660,7 +660,6 @@ type CreateGenericIntegrationMutationJSONBody struct {
 type CreateKubernetesIntegrationMutationJSONBody struct {
 	ClusterId     string  `json:"clusterId"`
 	EnvironmentId *string `json:"environmentId,omitempty"`
-	Name          string  `json:"name"`
 }
 
 // UpdateIntegrationMutationJSONBody defines parameters for UpdateIntegrationMutation.

--- a/src/pkg/cloudclient/restapi/cloudapi/openapi.json
+++ b/src/pkg/cloudclient/restapi/cloudapi/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Otterize API Server",
     "version": "v1beta",
-    "x-revision": "834e146d470ad9450662c4f325846724f032776b"
+    "x-revision": "a97941eb9c944f3c958664c532e98e21f1a9f881"
   },
   "servers": [
     {
@@ -2421,9 +2421,6 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "name": {
-                    "type": "string"
-                  },
                   "environmentId": {
                     "type": "string"
                   },
@@ -2432,7 +2429,6 @@
                   }
                 },
                 "required": [
-                  "name",
                   "clusterId"
                 ]
               }
@@ -2596,6 +2592,16 @@
         "type": "http",
         "scheme": "bearer",
         "bearerFormat": "JWT"
+      },
+      "oauth2": {
+        "type": "oauth2",
+        "description": "Use a Client ID and Client secret from an Otterize integration to authenticate.",
+        "flows": {
+          "clientCredentials": {
+            "tokenUrl": "/api/auth/tokens/token",
+            "scopes": {}
+          }
+        }
       },
       "organizationHeader": {
         "type": "apiKey",


### PR DESCRIPTION
K8s integration name is now auto-generated from the cluster name, so there is no need to provide a name anymore

https://www.notion.so/otterize/Autogenerated-integration-name-should-be-different-3e810219b32a46dba99c57353c0cd366
https://www.notion.so/otterize/Integrations-API-improvements-Kubernetes-integration-name-should-be-the-cluster-name-not-autogener-c31b4739d654423bad0d338aa49b158d