### PR TITLE
Fix multiple cluster config update

### DIFF
--- a/src/cmd/clusters/update/update-cluster.go
+++ b/src/cmd/clusters/update/update-cluster.go
@@ -32,23 +32,19 @@ var UpdateClusterCmd = &cobra.Command{
 
 		id := args[0]
 
-		var configuration *cloudapi.ClusterConfigurationInput
+		var configuration cloudapi.ClusterConfigurationInput
 		if viper.IsSet(GlobalDefaultDenyKey) {
-			configuration = &cloudapi.ClusterConfigurationInput{
-				GlobalDefaultDeny: viper.GetBool(GlobalDefaultDenyKey),
-			}
+			configuration.GlobalDefaultDeny = viper.GetBool(GlobalDefaultDenyKey)
 		}
 
 		if viper.IsSet(UseNetworkPoliciesInAccessGraphStatesKey) {
-			configuration = &cloudapi.ClusterConfigurationInput{
-				UseNetworkPoliciesInAccessGraphStates: viper.GetBool(UseNetworkPoliciesInAccessGraphStatesKey),
-			}
+			configuration.UseNetworkPoliciesInAccessGraphStates = viper.GetBool(UseNetworkPoliciesInAccessGraphStatesKey)
 		}
 
 		r, err := c.UpdateClusterMutationWithResponse(ctxTimeout,
 			id,
 			cloudapi.UpdateClusterMutationJSONRequestBody{
-				Configuration: configuration,
+				Configuration: &configuration,
 			},
 		)
 		if err != nil {


### PR DESCRIPTION
When user sent more than one config flag, the last one override the configuration object. 
This PR fix it to support setting multiple configurations at once.