### PR TITLE
Improve integration type error

### DIFF
--- a/src/cmd/integrations/list/list-integrations.go
+++ b/src/cmd/integrations/list/list-integrations.go
@@ -2,6 +2,7 @@ package list
 
 import (
 	"context"
+	"github.com/otterize/otterize-cli/src/pkg/cloudclient/enums"
 	cloudclient "github.com/otterize/otterize-cli/src/pkg/cloudclient/restapi"
 	"github.com/otterize/otterize-cli/src/pkg/cloudclient/restapi/cloudapi"
 	"github.com/otterize/otterize-cli/src/pkg/config"
@@ -32,16 +33,21 @@ var ListIntegrationsCmd = &cobra.Command{
 			return err
 		}
 
+		var integrationTypeParam *cloudapi.IntegrationsQueryParamsIntegrationType
+		if viper.IsSet(IntegrationTypeKey) {
+			integrationType, err := enums.IntegrationTypeFromString(viper.GetString(IntegrationTypeKey))
+			if err != nil {
+				return err
+			}
+			integrationTypeParam = lo.ToPtr(cloudapi.IntegrationsQueryParamsIntegrationType(integrationType))
+		}
+
 		r, err := c.IntegrationsQueryWithResponse(ctxTimeout,
 			&cloudapi.IntegrationsQueryParams{
-				Name: lo.Ternary(viper.IsSet(NameKey), lo.ToPtr(viper.GetString(NameKey)), nil),
-				IntegrationType: lo.Ternary(
-					viper.IsSet(IntegrationTypeKey),
-					lo.ToPtr(cloudapi.IntegrationsQueryParamsIntegrationType(viper.GetString(IntegrationTypeKey))),
-					nil,
-				),
-				EnvironmentId: lo.Ternary(viper.IsSet(EnvironmentIDKey), lo.ToPtr(viper.GetString(EnvironmentIDKey)), nil),
-				ClusterId:     lo.Ternary(viper.IsSet(ClusterIDKey), lo.ToPtr(viper.GetString(ClusterIDKey)), nil),
+				Name:            lo.Ternary(viper.IsSet(NameKey), lo.ToPtr(viper.GetString(NameKey)), nil),
+				IntegrationType: integrationTypeParam,
+				EnvironmentId:   lo.Ternary(viper.IsSet(EnvironmentIDKey), lo.ToPtr(viper.GetString(EnvironmentIDKey)), nil),
+				ClusterId:       lo.Ternary(viper.IsSet(ClusterIDKey), lo.ToPtr(viper.GetString(ClusterIDKey)), nil),
 			},
 		)
 		if err != nil {

--- a/src/pkg/cloudclient/enums/enums.go
+++ b/src/pkg/cloudclient/enums/enums.go
@@ -1,0 +1,27 @@
+package enums
+
+import (
+	"fmt"
+	"github.com/otterize/otterize-cli/src/pkg/cloudclient/restapi/cloudapi"
+	"github.com/samber/lo"
+	"strings"
+)
+
+var (
+	AllIntegrationTypes = []cloudapi.IntegrationType{cloudapi.IntegrationTypeKUBERNETES, cloudapi.IntegrationTypeGENERIC}
+)
+
+func formatTypesSlice[T comparable](types []T) string {
+	typeAsStrings := lo.Map(types, func(item T, _ int) string {
+		return fmt.Sprint(item)
+	})
+	return strings.Join(typeAsStrings, ", ")
+}
+
+func IntegrationTypeFromString(input string) (cloudapi.IntegrationType, error) {
+	inputType := cloudapi.IntegrationType(strings.TrimSpace(strings.ToUpper(input)))
+	if lo.Contains(AllIntegrationTypes, inputType) {
+		return inputType, nil
+	}
+	return "", fmt.Errorf("invalid integration type %s, valid types are: %s", input, formatTypesSlice(AllIntegrationTypes))
+}


### PR DESCRIPTION
There was an error when providing integration type with the wrong format:
```
# otterize integrations list --type=generic
Error: HTTP error 500 (Variable "$integrationType" got invalid value "generic"; Value "generic" does not exist in "IntegrationType" enum. Did you mean the enum value "GENERIC"?)
```

This PR:
* Makes the error nicer
* Makes the CLI case insensitive for this input

Fixes:
https://www.notion.so/otterize/Wrong-HTTP-status-for-integrations-query-d6c783b9be694650b5226d011ab66c0c