### PR TITLE
Removed go generate from build as it is not required so fix release github action

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,8 +4,7 @@ before:
   hooks:
     # You may remove this if you don't use go modules.
     - go mod tidy
-    # you may remove this if you don't need go generate
-    - go generate ./...
+
 builds:
   - id: default
     env:


### PR DESCRIPTION
Right now the release action fails on go generate.
Our go generate requires running an instance of the SOFA server to work, and because our generated code is committed anyway, it is not required to run go generate on the build.
