### PR TITLE
Move intents convert command back to under 'intents'

### DIFF
--- a/src/cmd/intents/convert/convert-intents.go
+++ b/src/cmd/intents/convert/convert-intents.go
@@ -36,7 +36,7 @@ func NewIntentsResourceFromIntentsSpec(spec v1alpha2.IntentsSpec) *v1alpha2.Clie
 }
 
 var ConvertCmd = &cobra.Command{
-	Use:   "intents-convert",
+	Use:   "convert",
 	Short: "Converts Otterize intents to Kubernetes ClientIntents resources",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/src/cmd/intents/intents.go
+++ b/src/cmd/intents/intents.go
@@ -2,6 +2,7 @@ package intents
 
 import (
 	"github.com/otterize/otterize-cli/src/cmd/groups"
+	"github.com/otterize/otterize-cli/src/cmd/intents/convert"
 	"github.com/otterize/otterize-cli/src/cmd/intents/get"
 	"github.com/otterize/otterize-cli/src/cmd/intents/list"
 	"github.com/spf13/cobra"
@@ -17,4 +18,5 @@ var IntentsCmd = &cobra.Command{
 func init() {
 	IntentsCmd.AddCommand(get.GetCmd)
 	IntentsCmd.AddCommand(list.ListCmd)
+	IntentsCmd.AddCommand(convert.ConvertCmd)
 }

--- a/src/cmd/networkmapper/mapper.go
+++ b/src/cmd/networkmapper/mapper.go
@@ -2,7 +2,6 @@ package networkmapper
 
 import (
 	"github.com/otterize/otterize-cli/src/cmd/groups"
-	"github.com/otterize/otterize-cli/src/cmd/networkmapper/convert"
 	"github.com/otterize/otterize-cli/src/cmd/networkmapper/export"
 	"github.com/otterize/otterize-cli/src/cmd/networkmapper/list"
 	"github.com/otterize/otterize-cli/src/cmd/networkmapper/reset"
@@ -25,5 +24,4 @@ func init() {
 	MapperCmd.AddCommand(export.ExportCmd)
 	MapperCmd.AddCommand(list.ListCmd)
 	MapperCmd.AddCommand(reset.ResetCmd)
-	MapperCmd.AddCommand(convert.ConvertCmd)
 }


### PR DESCRIPTION
This command was moved to the network-mapper command before, but per product request we'll be moving it back to under intents. 