### PR TITLE
Using generics better in types formatting function

### DIFF
--- a/src/pkg/cloudclient/enums/enums.go
+++ b/src/pkg/cloudclient/enums/enums.go
@@ -11,9 +11,9 @@ var (
 	AllIntegrationTypes = []cloudapi.IntegrationType{cloudapi.IntegrationTypeKUBERNETES, cloudapi.IntegrationTypeGENERIC}
 )
 
-func formatTypesSlice[T comparable](types []T) string {
+func formatTypesSlice[T ~string](types []T) string {
 	typeAsStrings := lo.Map(types, func(item T, _ int) string {
-		return fmt.Sprint(item)
+		return string(item)
 	})
 	return strings.Join(typeAsStrings, ", ")
 }


### PR DESCRIPTION
Because all enums are of string-ish types, it is better to use the `~string` constraint in the types formatting method so that we can use string conversion.
