### PR TITLE
Silence errors printed by kubeclient log

### DIFF
--- a/src/pkg/portforwarder/portforwarder.go
+++ b/src/pkg/portforwarder/portforwarder.go
@@ -3,9 +3,11 @@ package portforwarder
 import (
 	"context"
 	"fmt"
+	"github.com/spf13/cobra"
 	"io"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/portforward"
@@ -38,15 +40,18 @@ func (p *PortForwarder) Start(ctx context.Context) (localPort int, err error) {
 		return 0, err
 	}
 
+	// Hide internal errors from kubeclient. We will get them elsewhere when trying to use the portforwarding.
+	runtime.ErrorHandlers = []func(error){}
+
 	clientSet, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return 0, err
 	}
-	srv, err := clientSet.CoreV1().Services(p.namespace).Get(context.TODO(), p.serviceName, v1.GetOptions{})
+	srv, err := clientSet.CoreV1().Services(p.namespace).Get(ctx, p.serviceName, v1.GetOptions{})
 	if err != nil {
 		return 0, err
 	}
-	podList, err := clientSet.CoreV1().Pods(p.namespace).List(context.TODO(), v1.ListOptions{LabelSelector: labels.SelectorFromSet(srv.Spec.Selector).String()})
+	podList, err := clientSet.CoreV1().Pods(p.namespace).List(ctx, v1.ListOptions{LabelSelector: labels.SelectorFromSet(srv.Spec.Selector).String()})
 	if err != nil {
 		return 0, err
 	}
@@ -71,12 +76,14 @@ func (p *PortForwarder) Start(ctx context.Context) (localPort int, err error) {
 		return 0, err
 	}
 	go func() {
-		err = fw.ForwardPorts()
-		if err != nil {
-			panic(err)
-		}
+		cobra.CheckErr(fw.ForwardPorts())
 	}()
-	<-readyChan
+	select {
+	case <-readyChan:
+		break
+	case <-ctx.Done():
+		return 0, ctx.Err()
+	}
 	ports, err := fw.GetPorts()
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
Before this PR, the portforward kubeclient started by `otterize mapper` commands would sometimes emit errors when the connection was closed upon terminating. These errors were benign, and this logger is not necessary as we would've received the most relevant errors when trying to connect to the port forwarded port, or when starting the port forward.