### PR TITLE
Added linux+arm64 to ignore list 

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,6 +19,8 @@ builds:
         goarch: arm
       - goos: windows
         goarch: arm64
+      - goos: linux
+        goarch: arm64
     binary: otterize
     hooks:
       post:


### PR DESCRIPTION
### Description
Added linux+arm64 to ignore list because go-graphviz does not support linux+arm64
