### PR TITLE
Fix static linking with libc

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -64,6 +64,4 @@ jobs:
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           CGO_ENABLED: "1"
 
-      - name: Build
-        run: goreleaser release --snapshot --clean --split
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,6 +33,37 @@ jobs:
         with:
           go-version: '>=1.19.0'
 
+      - name: Install dependencies
+        if: matrix.os == 'macos-latest'
+        run: |-
+          brew install coreutils
+          brew install mitchellh/gon/gon
+
+      - name: Import Code-Signing Certificates
+        if: matrix.os == 'macos-latest'
+        uses: apple-actions/import-codesign-certs@253ddeeac23f2bdad1646faac5c8c2832e800071
+        with:
+          # The certificates in a PKCS12 file encoded as a base64 string
+          p12-file-base64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+          # The password used to import the PKCS12 file.
+          p12-password: ${{ secrets.P12_PASSWORD }}
+
+      - name: Install dependencies
+        if: matrix.os == 'ubuntu-latest'
+        run: |-
+          sudo apt install -y coreutils
+
+      - uses: goreleaser/goreleaser-action@v2
+        with:
+          distribution: goreleaser-pro
+          version: latest
+          args: release --clean --split
+        env:
+          GITHUB_TOKEN: ${{ secrets.OTTERIZEBOT_GITHUB_TOKEN }}
+          AC_PASSWORD: ${{ secrets.AC_PASSWORD }}
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+          CGO_ENABLED: "1"
+
       - name: Build
         run: goreleaser release --snapshot --clean --split
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,11 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Check out the code
         uses: actions/checkout@v2
@@ -30,5 +34,5 @@ jobs:
           go-version: '>=1.19.0'
 
       - name: Build
-        run: goreleaser release --snapshot --clean
+        run: goreleaser release --snapshot --clean --split
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,5 +30,5 @@ jobs:
           go-version: '>=1.19.0'
 
       - name: Build
-        run: go build ./src/cmd
+        run: goreleaser release --snapshot --clean
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,6 +20,11 @@ builds:
         goarch: "386"
       - goos: linux
         goarch: arm64
+    hooks:
+      post:
+        - output: true
+          # checks that we've successfully statically built this executable
+          cmd: ldd otterize 2>&1 | grep 'not a dynamic executable'
     binary: otterize
 
   - id: macos-amd

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -29,8 +29,8 @@ builds:
       - amd64
     main:
       ./src/cmd
-    ldflags:
-      - -linkmode 'external' -extldflags '-static'
+    # intentionally no static linking for macOS - from the man page for `gcc` on `-static`:
+    # This option will not work on Mac OS X unless all libraries (including libgcc.a) have also been compiled with -static. Since neither a static version of libSystem.dylib nor crt0.o are provided, this option is not useful to most people.
     binary: otterize
     hooks:
       post:
@@ -44,8 +44,8 @@ builds:
       - arm64
     main:
       ./src/cmd
-    ldflags:
-      - -linkmode 'external' -extldflags '-static'
+    # intentionally no static linking for macOS - from the man page for `gcc` on `-static`:
+    # This option will not work on Mac OS X unless all libraries (including libgcc.a) have also been compiled with -static. Since neither a static version of libSystem.dylib nor crt0.o are provided, this option is not useful to most people.
     binary: otterize
     hooks:
       post:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,7 +24,7 @@ builds:
       post:
         - output: true
           # checks that we've successfully statically built this executable
-          cmd: ldd {{ .Path }} 2>&1 | grep 'not a dynamic executable'
+          cmd: /bin/sh -c "ldd {{ .Path }} 2>&1 | grep 'not a dynamic executable'"
     binary: otterize
 
   - id: macos-amd

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -5,6 +5,8 @@ builds:
     goos:
       - linux
       - windows
+    ldflags:
+      - -linkmode 'external' -extldflags '-static'
     main:
       ./src/cmd
     ignore:
@@ -27,6 +29,8 @@ builds:
       - amd64
     main:
       ./src/cmd
+    ldflags:
+      - -linkmode 'external' -extldflags '-static'
     binary: otterize
     hooks:
       post:
@@ -40,6 +44,8 @@ builds:
       - arm64
     main:
       ./src/cmd
+    ldflags:
+      - -linkmode 'external' -extldflags '-static'
     binary: otterize
     hooks:
       post:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,9 +1,27 @@
 # This is an example .goreleaser.yml file with some sensible defaults.
 # Make sure to check the documentation at https://goreleaser.com
 builds:
-  - id: default
+  - id: linux
     goos:
       - linux
+    ldflags:
+      - -linkmode 'external' -extldflags '-static'
+    main:
+      ./src/cmd
+    ignore:
+      - goos: linux
+        goarch: "386"
+      - goos: linux
+        goarch: arm64
+    hooks:
+      post:
+        - output: true
+          # checks that we've successfully statically built this executable
+          cmd: /bin/sh -c "ldd {{ .Path }} 2>&1 | grep 'not a dynamic executable'"
+    binary: otterize
+
+  - id: windows
+    goos:
       - windows
     ldflags:
       - -linkmode 'external' -extldflags '-static'
@@ -16,15 +34,11 @@ builds:
         goarch: arm64
       - goos: windows
         goarch: "386"
-      - goos: linux
-        goarch: "386"
-      - goos: linux
-        goarch: arm64
     hooks:
       post:
         - output: true
           # checks that we've successfully statically built this executable
-          cmd: /bin/sh -c "ldd {{ .Path }} 2>&1 | grep 'not a dynamic executable'"
+          cmd: ldd {{ .Path }} 2>&1 | grep 'not a dynamic executable'
     binary: otterize
 
   - id: macos-amd

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,7 +24,7 @@ builds:
       post:
         - output: true
           # checks that we've successfully statically built this executable
-          cmd: ldd otterize 2>&1 | grep 'not a dynamic executable'
+          cmd: ldd {{ .Path }} 2>&1 | grep 'not a dynamic executable'
     binary: otterize
 
   - id: macos-amd
@@ -55,7 +55,7 @@ builds:
     hooks:
       post:
         - output: true
-          cmd: gon -log-level=debug gon_arm64.hcl
+          cmd: echo {{ .Path }}
     # no upx for mac arm - causes invalid instructions
 
 


### PR DESCRIPTION
The last release included `graphviz`, which introduced a dependency on `libc`. We didn't include flags for statically linking with libc, so if the relevant versions are missing, the CLI fails to start.