### PR TITLE
Bump otterize CLI version - use staging as source for version consistency

### DIFF
--- a/src/pkg/cloudclient/graphql/generate.go
+++ b/src/pkg/cloudclient/graphql/generate.go
@@ -2,5 +2,5 @@ package graphql
 
 import _ "github.com/suessflorian/gqlfetch"
 
-//go:generate sh -c "go run github.com/suessflorian/gqlfetch/gqlfetch --endpoint http://localhost:4000/api/graphql/v1beta > schema.graphql"
+//go:generate sh -c "go run github.com/suessflorian/gqlfetch/gqlfetch --endpoint https://app.staging.otterize.com/api/graphql/v1beta > schema.graphql"
 //go:generate go run github.com/Khan/genqlient ./genqlient.yaml

--- a/src/pkg/cloudclient/graphql/schema.graphql
+++ b/src/pkg/cloudclient/graphql/schema.graphql
@@ -445,6 +445,7 @@ type Mutation {
 """Update cluster"""
 	updateCluster(
 		id: ID!
+		name: String
 		configuration: ClusterConfigurationInput
 	): Cluster!
 """Create a new environment"""

--- a/src/pkg/cloudclient/restapi/cloudapi/api.gen.go
+++ b/src/pkg/cloudclient/restapi/cloudapi/api.gen.go
@@ -20,7 +20,6 @@ import (
 
 const (
 	AccessTokenCookieScopes  = "accessTokenCookie.Scopes"
-	BearerAuthScopes         = "bearerAuth.Scopes"
 	Oauth2Scopes             = "oauth2.Scopes"
 	OrganizationHeaderScopes = "organizationHeader.Scopes"
 )

--- a/src/pkg/cloudclient/restapi/cloudapi/openapi.json
+++ b/src/pkg/cloudclient/restapi/cloudapi/openapi.json
@@ -1179,19 +1179,13 @@
     },
     "securitySchemes": {
       "accessTokenCookie": {
-        "description": "Otterize user JWT token. This session cookie is automatically set by logging in to Otterize Cloud at https://app.otterize.com.",
+        "description": "Otterize user JWT token. This session cookie is automatically set by logging in to Otterize Cloud.",
         "in": "cookie",
         "name": "access_token",
         "type": "apiKey"
       },
-      "bearerAuth": {
-        "bearerFormat": "JWT",
-        "description": "Otterize user JWT token.",
-        "scheme": "bearer",
-        "type": "http"
-      },
       "oauth2": {
-        "description": "Use client ID and client secret from an Otterize integration to authenticate.\nTo create an integration, go to https://app.otterize.com/integrations.",
+        "description": "Use client ID and client secret from an Otterize integration to authenticate.",
         "flows": {
           "clientCredentials": {
             "scopes": {
@@ -1212,7 +1206,7 @@
   "info": {
     "title": "Otterize API Server",
     "version": "v1beta",
-    "x-revision": "6e740f335ec7294063f9d072fd214f8991b8a1f8"
+    "x-revision": "caead657cc0ed9aaa8849597c3562e1d7421897b"
   },
   "openapi": "3.0.0",
   "paths": {
@@ -4344,12 +4338,6 @@
     },
     {
       "accessTokenCookie": [
-      ],
-      "organizationHeader": [
-      ]
-    },
-    {
-      "bearerAuth": [
       ],
       "organizationHeader": [
       ]

--- a/src/pkg/cloudclient/restapi/generate.go
+++ b/src/pkg/cloudclient/restapi/generate.go
@@ -2,5 +2,5 @@ package restapi
 
 import _ "github.com/deepmap/oapi-codegen/pkg/codegen"
 
-//go:generate curl -s http://local.otterize.com:4000/api/rest/v1beta/openapi.json -o ./cloudapi/openapi.json
+//go:generate curl -s https://app.staging.otterize.com/api/rest/v1beta/openapi.json -o ./cloudapi/openapi.json
 //go:generate go run github.com/deepmap/oapi-codegen/cmd/oapi-codegen -o ./cloudapi/api.gen.go --package=cloudapi -generate=types,client ./cloudapi/openapi.json


### PR DESCRIPTION
### Description
Use https://app.staging.otterize.com/api as code generation source to guarantee API version consistency (local versioning has some development-only API options which mess up the version hash). 
This also makes the CLI's code generation consistent with all other opensource tools. 