### PR TITLE
Fixed a crash when "DESCRIBE_CONFIGS" operation was exported by the mapper export command

### DIFF
--- a/src/pkg/intentsoutput/transform.go
+++ b/src/pkg/intentsoutput/transform.go
@@ -181,6 +181,8 @@ func mapperKafkaOperationToAPI(operation mapperclient.KafkaOperation) v1alpha2.K
 		return v1alpha2.KafkaOperationIdempotentWrite
 	case mapperclient.KafkaOperationAlterConfigs:
 		return v1alpha2.KafkaOperationAlterConfigs
+	case mapperclient.KafkaOperationDescribeConfigs:
+		return v1alpha2.KafkaOperationDescribeConfigs
 	default:
 		panic("should never happen")
 	}


### PR DESCRIPTION
### Description
Since we had missing kafka operation in mapperKafkaOperationToAPI - "DESCRIBE_CONFIGS",
we've got panic errors.

Added this case to the switch case.

### Testing
- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist
- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
