### PR TITLE
Do not send previous selected organization ID to cloud on `otterize login`

### DIFF
--- a/src/pkg/cloudclient/login/userlogin/userlogin.go
+++ b/src/pkg/cloudclient/login/userlogin/userlogin.go
@@ -23,7 +23,7 @@ type LoginContext struct {
 }
 
 func NewContext(apiAddress string, accessToken string) (*LoginContext, error) {
-	apiClient, err := restapi.NewClientFromToken(apiAddress, accessToken)
+	apiClient, err := restapi.NewClientFromToken(apiAddress, accessToken, "")
 	if err != nil {
 		return nil, err
 	}

--- a/src/pkg/cloudclient/restapi/client.go
+++ b/src/pkg/cloudclient/restapi/client.go
@@ -25,10 +25,10 @@ type Doer interface {
 }
 
 func NewClient(ctx context.Context) (*Client, error) {
-	return NewClientFromToken(viper.GetString(config.OtterizeAPIAddressKey), auth.GetAPIToken(ctx))
+	return NewClientFromToken(viper.GetString(config.OtterizeAPIAddressKey), auth.GetAPIToken(ctx), viper.GetString(config.ApiSelectedOrganizationId))
 }
 
-func NewClientFromToken(apiRoot string, token string) (*Client, error) {
+func NewClientFromToken(apiRoot string, token string, orgId string) (*Client, error) {
 	restApiURL := apiRoot + "/rest/v1beta"
 	bearerTokenProvider, err := securityprovider.NewSecurityProviderBearerToken(token)
 	if err != nil {
@@ -39,8 +39,8 @@ func NewClientFromToken(apiRoot string, token string) (*Client, error) {
 		restApiURL,
 		cloudapi.WithRequestEditorFn(bearerTokenProvider.Intercept),
 		cloudapi.WithRequestEditorFn(func(ctx context.Context, req *http.Request) error {
-			if viper.IsSet(config.ApiSelectedOrganizationId) {
-				req.Header.Set("X-Otterize-Organization", viper.GetString(config.ApiSelectedOrganizationId))
+			if orgId != "" {
+				req.Header.Set("X-Otterize-Organization", orgId)
 			}
 			return nil
 		}),


### PR DESCRIPTION
### Description
On `otterize login`, the pre-selected org ID should not be sent when querying the current user information from the cloud API. That is because it might be an invalid organization ID, for example if the old organization has been removed, or if the called is switching users. 
The pre-selected org ID will be used only after validating it is, indeed, a valid organization for the logged-in user. 

### Testing
Reproducing the issue (prior to this fix):
1. Run `otterize login` and complete the login flow
2. Manually edit `~/.otterize/credentials`, set the `organization_id` to some invalid organization
3. Run `otterize login` again

Prior to this fix, the second run of `otterize login` would fail with HTTP error 403 (due to the invalid org). 
After this fix, on the second run of `otterize login`, the CLI will lead the user to re-select another, valid org. 