### PR TITLE
Add support for list/get/create database integrations

### DIFF
--- a/src/cmd/integrations/create/create-database-integration.go
+++ b/src/cmd/integrations/create/create-database-integration.go
@@ -1,0 +1,72 @@
+package create
+
+import (
+	"context"
+	cloudclient "github.com/otterize/otterize-cli/src/pkg/cloudclient/restapi"
+	"github.com/otterize/otterize-cli/src/pkg/cloudclient/restapi/cloudapi"
+	"github.com/otterize/otterize-cli/src/pkg/config"
+	"github.com/otterize/otterize-cli/src/pkg/output"
+	"github.com/samber/lo"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+const (
+	DatabaseAddress           = "address"
+	DatabaseAddressShorthand  = "a"
+	DatabaseUsername          = "username"
+	DatabaseUsernameShorthand = "u"
+	DatabasePassword          = "password"
+	DatabasePasswordShorthand = "p"
+	DatabaseType              = "type"
+	DatabaseTypeShorthand     = "t"
+)
+
+var CreateDatabaseIntegrationCmd = &cobra.Command{
+	Use:          "database",
+	Short:        "Create a database integration",
+	Args:         cobra.NoArgs,
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, args []string) error {
+		ctxTimeout, cancel := context.WithTimeout(context.Background(), config.DefaultTimeout)
+		defer cancel()
+
+		c, err := cloudclient.NewClient(ctxTimeout)
+		if err != nil {
+			return err
+		}
+
+		r, err := c.CreateDatabaseIntegrationMutationWithResponse(ctxTimeout,
+			cloudapi.CreateDatabaseIntegrationMutationJSONRequestBody{
+				Name: viper.GetString(NameKey),
+				DatabaseInfo: cloudapi.DatabaseInfoInput{
+					Address: viper.GetString(DatabaseAddress),
+					// TODO: check why this is not being generated?
+					Credentials: map[string]interface{}{
+						"username": viper.GetString(DatabaseUsername),
+						"password": viper.GetString(DatabasePassword),
+					},
+					DatabaseType: cloudapi.DatabaseInfoInputDatabaseType(viper.GetString(DatabaseType)),
+				},
+			})
+		if err != nil {
+			return err
+		}
+
+		output.FormatIntegrations([]cloudapi.Integration{lo.FromPtr(r.JSON200)}, true)
+		return nil
+	},
+}
+
+func init() {
+	CreateDatabaseIntegrationCmd.Flags().StringP(NameKey, NameShorthand, "", "integration name")
+	CreateDatabaseIntegrationCmd.Flags().StringP(DatabaseAddress, DatabaseAddressShorthand, "", "database address")
+	CreateDatabaseIntegrationCmd.Flags().StringP(DatabaseUsername, DatabaseUsernameShorthand, "", "database username")
+	CreateDatabaseIntegrationCmd.Flags().StringP(DatabasePassword, DatabasePasswordShorthand, "", "database password")
+	CreateDatabaseIntegrationCmd.Flags().StringP(DatabaseType, DatabaseTypeShorthand, "", "database type")
+	cobra.CheckErr(CreateDatabaseIntegrationCmd.MarkFlagRequired(NameKey))
+	cobra.CheckErr(CreateDatabaseIntegrationCmd.MarkFlagRequired(DatabaseAddress))
+	cobra.CheckErr(CreateDatabaseIntegrationCmd.MarkFlagRequired(DatabaseUsername))
+	cobra.CheckErr(CreateDatabaseIntegrationCmd.MarkFlagRequired(DatabasePassword))
+	cobra.CheckErr(CreateDatabaseIntegrationCmd.MarkFlagRequired(DatabasePassword))
+}

--- a/src/cmd/integrations/create/create-database-integration.go
+++ b/src/cmd/integrations/create/create-database-integration.go
@@ -41,7 +41,6 @@ var CreateDatabaseIntegrationCmd = &cobra.Command{
 				Name: viper.GetString(NameKey),
 				DatabaseInfo: cloudapi.DatabaseInfoInput{
 					Address: viper.GetString(DatabaseAddress),
-					// TODO: check why this is not being generated?
 					Credentials: map[string]interface{}{
 						"username": viper.GetString(DatabaseUsername),
 						"password": viper.GetString(DatabasePassword),

--- a/src/cmd/integrations/create/create-integration.go
+++ b/src/cmd/integrations/create/create-integration.go
@@ -12,4 +12,5 @@ var CreateIntegrationCmd = &cobra.Command{
 func init() {
 	CreateIntegrationCmd.AddCommand(CreateKubernetesIntegrationCmd)
 	CreateIntegrationCmd.AddCommand(CreateGenericIntegrationCmd)
+	CreateIntegrationCmd.AddCommand(CreateDatabaseIntegrationCmd)
 }

--- a/src/pkg/cloudclient/enums/enums.go
+++ b/src/pkg/cloudclient/enums/enums.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	AllIntegrationTypes = []cloudapi.IntegrationType{cloudapi.IntegrationTypeKUBERNETES, cloudapi.IntegrationTypeGENERIC}
+	AllIntegrationTypes = []cloudapi.IntegrationType{cloudapi.IntegrationTypeKUBERNETES, cloudapi.IntegrationTypeGENERIC, cloudapi.IntegrationTypeDATABASE}
 )
 
 func formatTypesSlice[T ~string](types []T) string {

--- a/src/pkg/cloudclient/graphql/schema.graphql
+++ b/src/pkg/cloudclient/graphql/schema.graphql
@@ -1,26 +1,98 @@
-"""Directs the executor to include this field or fragment only when the `if` argument is true."""
-directive @include(
-"""Included when true."""
-	if: Boolean!
-) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+"""@auth indicates that the specified query / mutation / subscription requires user authentication"""
+directive @auth on FIELD_DEFINITION
 
-"""Directs the executor to skip this field or fragment when the `if` argument is true."""
-directive @skip(
-"""Skipped when true."""
-	if: Boolean!
-) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+directive @constraint(
+	tag: String!
+	pattern: String!
+	example: String!
+) on ENUM_VALUE
 
-"""Marks an element of a GraphQL schema as no longer supported."""
+"""The @deprecated built-in directive is used within the type system definition language to indicate deprecated portions of a GraphQL service's schema, such as deprecated fields on a type, arguments on a field, input fields on an input type, or values of an enum type."""
 directive @deprecated(
-"""Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted using the Markdown syntax, as specified by [CommonMark](https://commonmark.org/)."""
 	reason: String
 ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | ENUM_VALUE
 
-"""Exposes a URL that specifies the behavior of this scalar."""
+directive @goField(
+	forceResolver: Boolean
+	name: String
+) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION
+
+directive @httpError(
+	statusCode: Int!
+) on ENUM_VALUE
+
+"""The @include directive may be provided for fields, fragment spreads, and inline fragments, and allows for conditional inclusion during execution as described by the if argument."""
+directive @include(
+	if: Boolean!
+) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+"""@noauth indicates that the specified query / mutation / subscription can be executed anonymously without
+user authentication, meaning anyone and everyone can execute it. USE WITH CAUTION."""
+directive @noauth on FIELD_DEFINITION
+
+directive @restApiField(
+	action: ApiFieldAction
+) on FIELD_DEFINITION
+
+directive @restApiRoute(
+	method: ApiMethod!
+	path: String!
+	tags: [String!]!
+) on FIELD_DEFINITION
+
+"""The @skip directive may be provided for fields, fragment spreads, and inline fragments, and allows for conditional exclusion during execution as described by the if argument."""
+directive @skip(
+	if: Boolean!
+) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+"""The @specifiedBy built-in directive is used within the type system definition language to provide a scalar specification URL for specifying the behavior of custom scalar types."""
 directive @specifiedBy(
-"""The URL that specifies the behavior of this scalar."""
 	url: String!
 ) on SCALAR
+
+"""@validate should be applied on API input fields / arguments, to enforce API input validation.
+See https://github.com/go-playground/validator for possible built-in constraints,
+and github.com/otterize/cloud/src/shared/directives/customvalidations for custom contraints."""
+directive @validate(
+	constraint: String
+	customConstraint: CustomConstraint
+) on INPUT_FIELD_DEFINITION | ARGUMENT_DEFINITION
+
+type AWSGeneralResource {
+	resource: String!
+	isWildcard: Boolean!
+}
+
+type AWSInfo {
+	region: String!
+	namespace: String!
+	eksClusterName: String!
+	awsAccountId: String!
+}
+
+input AWSInfoInput {
+	clusterId: ID!
+	region: String!
+	namespace: String!
+	eksClusterName: String!
+	awsAccountId: String!
+}
+
+type AWSResource {
+	type: AWSResourceType!
+	info: AWSResourceInfo!
+}
+
+union AWSResourceInfo =AWSS3Resource | AWSGeneralResource
+
+enum AWSResourceType {
+	GENERAL
+	S3
+}
+
+type AWSS3Resource {
+	bucketName: String!
+}
 
 type AccessGraph {
 	filter: AccessGraphFilter!
@@ -29,9 +101,6 @@ type AccessGraph {
 	serviceAccessGraphs: [ServiceAccessGraph!]!
 	serviceCount: Int!
 }
-
-"""The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1."""
-scalar Int
 
 type AccessGraphEdge {
 	client: Service!
@@ -50,12 +119,6 @@ type AccessGraphFilter {
 	includeServicesWithNoEdges: Boolean
 }
 
-"""The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `"4"`) or integer (such as `4`) input value will be accepted as an ID."""
-scalar ID
-
-"""The `Boolean` scalar type represents `true` or `false`."""
-scalar Boolean
-
 enum ApiFieldAction {
 """Do nothing, expose models to the REST API as id-only structs (Default behaviour)"""
 	COLLAPSE_MODEL
@@ -73,39 +136,24 @@ enum ApiMethod {
 	DELETE
 }
 
-type AWSGeneralResource {
-	resource: String!
-	isWildcard: Boolean!
+"""The `Boolean` scalar type represents `true` or `false`."""
+scalar Boolean
+
+input CLICommand {
+	noun: String!
+	verb: String!
+	modifiers: [String!]
 }
 
-"""The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."""
-scalar String
-
-type AWSInfo {
-	region: String!
-	namespace: String!
+input CLIIdentifier {
+	version: String!
+	contextId: String!
+	cloudClientId: String
 }
 
-input AWSInfoInput {
-	clusterId: ID!
-	region: String!
-	namespace: String!
-}
-
-type AWSResource {
-	type: AWSResourceType!
-	info: AWSResourceInfo!
-}
-
-union AWSResourceInfo =AWSS3Resource | AWSGeneralResource
-
-enum AWSResourceType {
-	GENERAL
-	S3
-}
-
-type AWSS3Resource {
-	bucketName: String!
+input CLITelemetry {
+	identifier: CLIIdentifier!
+	command: CLICommand!
 }
 
 input CertificateCustomization {
@@ -126,15 +174,16 @@ enum CertificateProvider {
 	NONE
 }
 
-type Client {
-	id: ID!
-	secret: String!
-}
-
 type ClientIntentsFileRepresentation {
+	fileName: String!
 	service: Service!
 	rows: [ClientIntentsRow!]!
 	content: String!
+}
+
+type ClientIntentsFiles {
+	files: [ClientIntentsFileRepresentation!]!
+	mergedYAMLFile: MergedYAMLFile
 }
 
 type ClientIntentsRow {
@@ -184,6 +233,14 @@ input ClusterFormSettingsInput {
 	enforcement: Boolean!
 }
 
+input Component {
+	componentType: TelemetryComponentType!
+	componentInstanceId: ID!
+	contextId: ID!
+	version: String!
+	cloudClientId: String
+}
+
 type ComponentStatus {
 	type: ComponentStatusType!
 	lastSeen: Time
@@ -215,12 +272,19 @@ enum CustomConstraint {
 	ID
 }
 
+enum DBPermissionChange {
+	APPLY
+	DELETE
+}
+
 type DatabaseConfig {
+	dbname: String!
 	table: String!
 	operations: [DatabaseOperation!]
 }
 
 input DatabaseConfigInput {
+	dbname: String!
 	table: String!
 	operations: [DatabaseOperation!]!
 }
@@ -231,13 +295,11 @@ input DatabaseCredentialsInput {
 }
 
 type DatabaseInfo {
-	name: String!
 	address: String!
 	databaseType: DatabaseType!
 }
 
 input DatabaseInfoInput {
-	name: String!
 	address: String!
 	databaseType: DatabaseType!
 	credentials: DatabaseCredentialsInput!
@@ -253,11 +315,6 @@ enum DatabaseOperation {
 
 enum DatabaseType {
 	POSTGRESQL
-}
-
-enum DBPermissionChange {
-	APPLY
-	DELETE
 }
 
 input DiscoveredIntentInput {
@@ -319,6 +376,38 @@ type Environment {
 	appliedIntentsCount: Int!
 }
 
+enum EventType {
+	INTENTS_DELETED
+	INTENTS_APPLIED
+	INTENTS_APPLIED_KAFKA
+	INTENTS_APPLIED_HTTP
+	INTENTS_APPLIED_DATABASE
+	INTENTS_DISCOVERED
+	INTENTS_DISCOVERED_SOCKET_SCAN
+	INTENTS_DISCOVERED_CAPTURE
+	INTENTS_DISCOVERED_KAFKA
+	INTENTS_DISCOVERED_ISTIO
+	MAPPER_EXPORT
+	MAPPER_VISUALIZE
+	KAFKA_SERVER_CONFIG_APPLIED
+	KAFKA_SERVER_CONFIG_DELETED
+	NETWORK_POLICIES_CREATED
+	NETWORK_POLICIES_DELETED
+	KAFKA_ACLS_CREATED
+	KAFKA_ACLS_DELETED
+	ISTIO_POLICIES_CREATED
+	ISTIO_POLICIES_DELETED
+	STARTED
+	SERVICE_DISCOVERED
+	NAMESPACE_DISCOVERED
+	PROTECTED_SERVICE_APPLIED
+	PROTECTED_SERVICE_DELETED
+	ACTIVE
+}
+
+"""The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point)."""
+scalar Float
+
 type HTTPConfig {
 	path: String!
 	methods: [HTTPMethod!]
@@ -341,6 +430,9 @@ enum HTTPMethod {
 	ALL
 }
 
+"""The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as "4") or integer (such as 4) input value will be accepted as an ID."""
+scalar ID
+
 input InputAccessGraphFilter {
 	environmentIds: [ID!]
 	clusterIds: [ID!]
@@ -349,6 +441,9 @@ input InputAccessGraphFilter {
 	lastSeenAfter: Time
 	includeServicesWithNoEdges: Boolean
 }
+
+"""The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1."""
+scalar Int
 
 type Integration {
 	id: ID!
@@ -405,6 +500,25 @@ input IntentInput {
 	status: IntentStatusInput
 }
 
+type IntentStatus {
+	serviceAccountName: String!
+	isServiceAccountShared: Boolean!
+	isServerMissingSidecar: Boolean!
+	isClientMissingSidecar: Boolean!
+}
+
+input IntentStatusInput {
+	istioStatus: IstioStatusInput
+}
+
+enum IntentType {
+	HTTP
+	KAFKA
+	DATABASE
+	AWS
+	S3
+}
+
 type IntentsOperatorComponent {
 	type: ComponentType!
 	status: ComponentStatus!
@@ -426,25 +540,6 @@ input IntentsOperatorConfigurationInput {
 	kafkaACLEnforcementEnabled: Boolean
 	istioPolicyEnforcementEnabled: Boolean
 	protectedServicesEnabled: Boolean
-}
-
-type IntentStatus {
-	serviceAccountName: String!
-	isServiceAccountShared: Boolean!
-	isServerMissingSidecar: Boolean!
-	isClientMissingSidecar: Boolean!
-}
-
-input IntentStatusInput {
-	istioStatus: IstioStatusInput
-}
-
-enum IntentType {
-	HTTP
-	KAFKA
-	DATABASE
-	AWS
-	S3
 }
 
 type Invite {
@@ -560,44 +655,15 @@ type MeMutation {
 	registerUser: Me!
 }
 
+type MergedYAMLFile {
+	fileName: String!
+	rows: [ClientIntentsRow!]!
+	content: String!
+}
+
 type Mutation {
 """This is just a placeholder since currently GraphQL does not allow empty types"""
 	dummy: Boolean
-"""Create client"""
-	createClient: Client!
-"""Delete client"""
-	deleteClient(
-		id: ID!
-	): ID!
-"""Create user invite"""
-	createInvite(
-		email: String!
-	): Invite!
-"""Delete user invite"""
-	deleteInvite(
-		id: ID!
-	): ID!
-"""Accept user invite"""
-	acceptInvite(
-		id: ID!
-	): Invite!
-"""Operate on the current logged-in user"""
-	me: MeMutation!
-"""Create a new organization"""
-	createOrganization(
-		name: String
-	): Organization!
-"""Update organization"""
-	updateOrganization(
-		id: ID!
-		name: String
-		imageURL: String
-	): Organization!
-"""Remove user from organization"""
-	removeUserFromOrganization(
-		id: ID!
-		userId: ID!
-	): ID!
 """Register certificate-request details for kubernetes pod owner, returns the service associated with this pod owner"""
 	registerKubernetesPodOwnerCertificateRequest(
 		podOwner: NamespacedPodOwner!
@@ -711,18 +777,53 @@ type Mutation {
 		namespace: String!
 		policies: [NetworkPolicyInput!]!
 	): Boolean!
+"""Create user invite"""
+	createInvite(
+		email: String!
+	): Invite!
+"""Delete user invite"""
+	deleteInvite(
+		id: ID!
+	): ID!
+"""Accept user invite"""
+	acceptInvite(
+		id: ID!
+	): Invite!
 	reportKafkaServerConfigs(
 		namespace: String!
 		serverConfigs: [KafkaServerConfigInput!]!
 	): Boolean!
+"""Operate on the current logged-in user"""
+	me: MeMutation!
 """Associate namespace to environment"""
 	associateNamespaceToEnv(
 		id: ID!
 		environmentId: ID
 	): Namespace!
+"""Create a new organization"""
+	createOrganization(
+		name: String
+	): Organization!
+"""Update organization"""
+	updateOrganization(
+		id: ID!
+		name: String
+		imageURL: String
+	): Organization!
+"""Remove user from organization"""
+	removeUserFromOrganization(
+		id: ID!
+		userId: ID!
+	): ID!
 	reportProtectedServicesSnapshot(
 		namespace: String!
 		services: [ProtectedServiceInput!]!
+	): Boolean!
+	sendTelemetries(
+		telemetries: [TelemetryInput!]!
+	): Boolean!
+	sendCLITelemetries(
+		telemetries: [CLITelemetry!]!
 	): Boolean!
 }
 
@@ -765,38 +866,6 @@ input ProtectedServiceInput {
 type Query {
 """This is just a placeholder since currently GraphQL does not allow empty types"""
 	dummy: Boolean
-"""Get client"""
-	client(
-		id: ID!
-	): Client!
-"""List user invites"""
-	invites(
-		email: String
-		status: InviteStatus
-	): [Invite!]!
-"""Get user invite"""
-	invite(
-		id: ID!
-	): Invite!
-"""Get one user invite"""
-	oneInvite(
-		email: String
-		status: InviteStatus
-	): Invite!
-"""Get information regarding the current logged-in user"""
-	me: Me!
-"""List organizations"""
-	organizations: [Organization!]!
-"""Get organization"""
-	organization(
-		id: ID!
-	): Organization!
-"""List users"""
-	users: [User!]!
-"""Get user"""
-	user(
-		id: ID!
-	): User!
 """Get access graph"""
 	accessGraph(
 		filter: InputAccessGraphFilter
@@ -852,6 +921,25 @@ type Query {
 		clusterId: ID
 		name: String
 	): Integration!
+	testDatabaseConnection(
+		databaseInfo: DatabaseInfoInput!
+	): TestDatabaseConnectionResponse!
+"""List user invites"""
+	invites(
+		email: String
+		status: InviteStatus
+	): [Invite!]!
+"""Get user invite"""
+	invite(
+		id: ID!
+	): Invite!
+"""Get one user invite"""
+	oneInvite(
+		email: String
+		status: InviteStatus
+	): Invite!
+"""Get information regarding the current logged-in user"""
+	me: Me!
 """Get namespace"""
 	namespace(
 		id: ID!
@@ -868,6 +956,12 @@ type Query {
 		clusterId: ID
 		name: String
 	): Namespace!
+"""List organizations"""
+	organizations: [Organization!]!
+"""Get organization"""
+	organization(
+		id: ID!
+	): Organization!
 """Get service"""
 	service(
 		id: ID!
@@ -884,6 +978,12 @@ type Query {
 		namespaceId: ID
 		name: String
 	): Service
+"""List users"""
+	users: [User!]!
+"""Get user"""
+	user(
+		id: ID!
+	): User!
 }
 
 enum RowDiff {
@@ -917,12 +1017,6 @@ type ServerProtectionStatus {
 	reason: ServerProtectionStatusReason!
 }
 
-type ServerProtectionStatuses {
-	networkPolicies: ServerProtectionStatus!
-	kafkaACLs: ServerProtectionStatus!
-	istioPolicies: ServerProtectionStatus!
-}
-
 enum ServerProtectionStatusReason {
 	INTENTS_OPERATOR_NEVER_CONNECTED
 	INTENTS_OPERATOR_NOT_ENFORCING
@@ -945,6 +1039,12 @@ enum ServerProtectionStatusVerdict {
 	UNKNOWN
 	UNPROTECTED
 	PROTECTED
+}
+
+type ServerProtectionStatuses {
+	networkPolicies: ServerProtectionStatus!
+	kafkaACLs: ServerProtectionStatus!
+	istioPolicies: ServerProtectionStatus!
 }
 
 type Service {
@@ -979,8 +1079,8 @@ type ServiceAccessStatus {
 }
 
 type ServiceClientIntents {
-	asClient: [ClientIntentsFileRepresentation!]!
-	asServer: [ClientIntentsFileRepresentation!]!
+	asClient: ClientIntentsFiles
+	asServer: ClientIntentsFiles
 }
 
 enum ServiceType {
@@ -988,6 +1088,31 @@ enum ServiceType {
 	KAFKA
 	AWS
 	DATABASE
+}
+
+"""The `String`scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."""
+scalar String
+
+enum TelemetryComponentType {
+	INTENTS_OPERATOR
+	CREDENTIALS_OPERATOR
+	NETWORK_MAPPER
+	CLI
+}
+
+input TelemetryData {
+	eventType: EventType!
+	count: Int
+}
+
+input TelemetryInput {
+	component: Component!
+	data: TelemetryData!
+}
+
+type TestDatabaseConnectionResponse {
+	success: Boolean!
+	errorMessage: String!
 }
 
 scalar Time
@@ -1003,6 +1128,16 @@ type User {
 type UserAndPassword {
 	username: String!
 	password: String!
+}
+
+enum UserErrorType {
+	UNAUTHENTICATED
+	NOT_FOUND
+	INTERNAL_SERVER_ERROR
+	BAD_REQUEST
+	FORBIDDEN
+	CONFLICT
+	BAD_USER_INPUT
 }
 
 

--- a/src/pkg/cloudclient/restapi/cloudapi/openapi.json
+++ b/src/pkg/cloudclient/restapi/cloudapi/openapi.json
@@ -99,6 +99,12 @@
       },
       "AWSInfo": {
         "properties": {
+          "awsAccountId": {
+            "type": "string"
+          },
+          "eksClusterName": {
+            "type": "string"
+          },
           "namespace": {
             "type": "string"
           },
@@ -108,13 +114,21 @@
         },
         "required": [
           "region",
-          "namespace"
+          "namespace",
+          "eksClusterName",
+          "awsAccountId"
         ],
         "type": "object"
       },
       "AWSInfoInput": {
         "properties": {
+          "awsAccountId": {
+            "type": "string"
+          },
           "clusterId": {
+            "type": "string"
+          },
+          "eksClusterName": {
             "type": "string"
           },
           "namespace": {
@@ -127,7 +141,9 @@
         "required": [
           "clusterId",
           "region",
-          "namespace"
+          "namespace",
+          "eksClusterName",
+          "awsAccountId"
         ],
         "type": "object"
       },
@@ -547,6 +563,9 @@
       },
       "DatabaseConfig": {
         "properties": {
+          "dbname": {
+            "type": "string"
+          },
           "operations": {
             "items": {
               "enum": [
@@ -565,7 +584,38 @@
           }
         },
         "required": [
+          "dbname",
           "table"
+        ],
+        "type": "object"
+      },
+      "DatabaseCredentials": {
+        "properties": {
+          "password": {
+            "type": "string"
+          },
+          "username": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "username",
+          "password"
+        ],
+        "type": "object"
+      },
+      "DatabaseCredentialsInput": {
+        "properties": {
+          "password": {
+            "type": "string"
+          },
+          "username": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "username",
+          "password"
         ],
         "type": "object"
       },
@@ -574,20 +624,42 @@
           "address": {
             "type": "string"
           },
+          "credentials": {
+            "$ref": "#/components/schemas/DatabaseCredentials"
+          },
           "databaseType": {
             "enum": [
               "POSTGRESQL"
             ],
             "type": "string"
+          }
+        },
+        "required": [
+          "address",
+          "databaseType",
+          "credentials"
+        ],
+        "type": "object"
+      },
+      "DatabaseInfoInput": {
+        "properties": {
+          "address": {
+            "type": "string"
           },
-          "name": {
+          "credentials": {
+            "type": "object"
+          },
+          "databaseType": {
+            "enum": [
+              "POSTGRESQL"
+            ],
             "type": "string"
           }
         },
         "required": [
-          "name",
           "address",
-          "databaseType"
+          "databaseType",
+          "credentials"
         ],
         "type": "object"
       },
@@ -1599,6 +1671,12 @@
         "name": "access_token",
         "type": "apiKey"
       },
+      "bearerAuth": {
+        "bearerFormat": "JWT",
+        "description": "Otterize user JWT token.",
+        "scheme": "bearer",
+        "type": "http"
+      },
       "oauth2": {
         "description": "Use client ID and client secret from an Otterize integration to authenticate.",
         "flows": {
@@ -1621,7 +1699,7 @@
   "info": {
     "title": "Otterize API Server",
     "version": "v1beta",
-    "x-revision": "d3e45693e17bd5c7f09108e2f5dd3ccb81bf5ca5"
+    "x-revision": "aa694dd58f27af248fe0a3aa24753b6525062889"
   },
   "openapi": "3.0.0",
   "paths": {
@@ -2960,6 +3038,160 @@
         ]
       }
     },
+    "/integrations/database": {
+      "post": {
+        "description": "",
+        "operationId": "createDatabaseIntegration_mutation",
+        "parameters": [
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "databaseInfo": {
+                    "$ref": "#/components/schemas/DatabaseInfoInput"
+                  },
+                  "name": {
+                    "example": "Object name",
+                    "format": "custom-name",
+                    "pattern": "^[A-Za-z][A-Za-z0-9- _]{0,61}[A-Za-z0-9]$",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "databaseInfo"
+                ],
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Integration"
+                }
+              }
+            },
+            "description": ""
+          },
+          "400": {
+            "$ref": "#/components/responses/BAD_REQUEST"
+          },
+          "401": {
+            "$ref": "#/components/responses/UNAUTHENTICATED"
+          },
+          "403": {
+            "$ref": "#/components/responses/FORBIDDEN"
+          },
+          "404": {
+            "$ref": "#/components/responses/NOT_FOUND"
+          },
+          "409": {
+            "$ref": "#/components/responses/CONFLICT"
+          },
+          "422": {
+            "$ref": "#/components/responses/BAD_USER_INPUT"
+          },
+          "500": {
+            "$ref": "#/components/responses/INTERNAL_SERVER_ERROR"
+          },
+          "default": {
+            "$ref": "#/components/responses/UNEXPECTED_ERROR"
+          }
+        },
+        "summary": "",
+        "tags": [
+          "integrations"
+        ]
+      }
+    },
+    "/integrations/database/{id}": {
+      "patch": {
+        "description": "Update Database integration",
+        "operationId": "updateDatabaseIntegration_mutation",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "example": "obj_12345",
+              "format": "id",
+              "pattern": "^[A-Za-z_]+_[a-z0-9]+$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "properties": {
+                  "databaseInfo": {
+                    "$ref": "#/components/schemas/DatabaseInfoInput"
+                  },
+                  "name": {
+                    "example": "Object name",
+                    "format": "custom-name",
+                    "pattern": "^[A-Za-z][A-Za-z0-9- _]{0,61}[A-Za-z0-9]$",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "databaseInfo"
+                ],
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Integration"
+                }
+              }
+            },
+            "description": "Update Database integration"
+          },
+          "400": {
+            "$ref": "#/components/responses/BAD_REQUEST"
+          },
+          "401": {
+            "$ref": "#/components/responses/UNAUTHENTICATED"
+          },
+          "403": {
+            "$ref": "#/components/responses/FORBIDDEN"
+          },
+          "404": {
+            "$ref": "#/components/responses/NOT_FOUND"
+          },
+          "409": {
+            "$ref": "#/components/responses/CONFLICT"
+          },
+          "422": {
+            "$ref": "#/components/responses/BAD_USER_INPUT"
+          },
+          "500": {
+            "$ref": "#/components/responses/INTERNAL_SERVER_ERROR"
+          },
+          "default": {
+            "$ref": "#/components/responses/UNEXPECTED_ERROR"
+          }
+        },
+        "summary": "Update Database integration",
+        "tags": [
+          "integrations"
+        ]
+      }
+    },
     "/integrations/generic": {
       "post": {
         "description": "Create a new generic integration",
@@ -4027,7 +4259,7 @@
         },
         "summary": "Get namespace",
         "tags": [
-          "namespace"
+          "namespaces"
         ]
       }
     },
@@ -4767,6 +4999,12 @@
     },
     {
       "accessTokenCookie": [
+      ],
+      "organizationHeader": [
+      ]
+    },
+    {
+      "bearerAuth": [
       ],
       "organizationHeader": [
       ]

--- a/src/pkg/output/formatters.go
+++ b/src/pkg/output/formatters.go
@@ -54,6 +54,13 @@ func FormatIntegrations(integrations []cloudapi.Integration, includeCreds bool) 
 		columns = append(columns, "CLIENT ID", "CLIENT SECRET")
 	}
 
+	for _, integration := range integrations {
+		if integration.Type == cloudapi.IntegrationTypeDATABASE {
+			columns = append(columns, "DATABASE ADDRESS", "DATABASE CREDENTIALS")
+			break
+		}
+	}
+
 	getColumnData := func(integration cloudapi.Integration) []map[string]string {
 		integrationColumns := map[string]string{
 			"ID":                     integration.Id,
@@ -66,6 +73,11 @@ func FormatIntegrations(integrations []cloudapi.Integration, includeCreds bool) 
 			integrationColumns["INTENTS OPERATOR"] = formatComponentStatus(integration.Components.IntentsOperator.Status)
 			integrationColumns["CREDENTIALS OPERATOR"] = formatComponentStatus(integration.Components.CredentialsOperator.Status)
 			integrationColumns["NETWORK MAPPER"] = formatComponentStatus(integration.Components.NetworkMapper.Status)
+		}
+
+		if integration.Type == cloudapi.IntegrationTypeDATABASE {
+			integrationColumns["DATABASE ADDRESS"] = integration.DatabaseInfo.Address
+			integrationColumns["DATABASE CREDENTIALS"] = fmt.Sprintf("%s:******", integration.DatabaseInfo.Credentials.Username)
 		}
 
 		if includeCreds {

--- a/src/pkg/telemetry/telemetrygql/schema.graphql
+++ b/src/pkg/telemetry/telemetrygql/schema.graphql
@@ -1,12 +1,44 @@
+"""@auth indicates that the specified query / mutation / subscription requires user authentication"""
+directive @auth on FIELD_DEFINITION
+
+directive @constraint(
+	tag: String!
+	pattern: String!
+	example: String!
+) on ENUM_VALUE
+
 """The @deprecated built-in directive is used within the type system definition language to indicate deprecated portions of a GraphQL service's schema, such as deprecated fields on a type, arguments on a field, input fields on an input type, or values of an enum type."""
 directive @deprecated(
 	reason: String
 ) on FIELD_DEFINITION | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION | ENUM_VALUE
 
+directive @goField(
+	forceResolver: Boolean
+	name: String
+) on INPUT_FIELD_DEFINITION | FIELD_DEFINITION
+
+directive @httpError(
+	statusCode: Int!
+) on ENUM_VALUE
+
 """The @include directive may be provided for fields, fragment spreads, and inline fragments, and allows for conditional inclusion during execution as described by the if argument."""
 directive @include(
 	if: Boolean!
 ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+"""@noauth indicates that the specified query / mutation / subscription can be executed anonymously without
+user authentication, meaning anyone and everyone can execute it. USE WITH CAUTION."""
+directive @noauth on FIELD_DEFINITION
+
+directive @restApiField(
+	action: ApiFieldAction
+) on FIELD_DEFINITION
+
+directive @restApiRoute(
+	method: ApiMethod!
+	path: String!
+	tags: [String!]!
+) on FIELD_DEFINITION
 
 """The @skip directive may be provided for fields, fragment spreads, and inline fragments, and allows for conditional exclusion during execution as described by the if argument."""
 directive @skip(
@@ -17,6 +49,92 @@ directive @skip(
 directive @specifiedBy(
 	url: String!
 ) on SCALAR
+
+"""@validate should be applied on API input fields / arguments, to enforce API input validation.
+See https://github.com/go-playground/validator for possible built-in constraints,
+and github.com/otterize/cloud/src/shared/directives/customvalidations for custom contraints."""
+directive @validate(
+	constraint: String
+	customConstraint: CustomConstraint
+) on INPUT_FIELD_DEFINITION | ARGUMENT_DEFINITION
+
+type AWSGeneralResource {
+	resource: String!
+	isWildcard: Boolean!
+}
+
+type AWSInfo {
+	region: String!
+	namespace: String!
+	eksClusterName: String!
+	awsAccountId: String!
+}
+
+input AWSInfoInput {
+	clusterId: ID!
+	region: String!
+	namespace: String!
+	eksClusterName: String!
+	awsAccountId: String!
+}
+
+type AWSResource {
+	type: AWSResourceType!
+	info: AWSResourceInfo!
+}
+
+union AWSResourceInfo =AWSS3Resource | AWSGeneralResource
+
+enum AWSResourceType {
+	GENERAL
+	S3
+}
+
+type AWSS3Resource {
+	bucketName: String!
+}
+
+type AccessGraph {
+	filter: AccessGraphFilter!
+"""Clusters for which there are results"""
+	clusters: [Cluster!]!
+	serviceAccessGraphs: [ServiceAccessGraph!]!
+	serviceCount: Int!
+}
+
+type AccessGraphEdge {
+	client: Service!
+	server: Service!
+	discoveredIntents: [Intent!]!
+	appliedIntents: [Intent!]!
+	accessStatus: EdgeAccessStatus!
+}
+
+type AccessGraphFilter {
+	environmentIds: [ID!]
+	clusterIds: [ID!]
+	namespaceIds: [ID!]
+	serviceIds: [ID!]
+	lastSeenAfter: Time
+	includeServicesWithNoEdges: Boolean
+}
+
+enum ApiFieldAction {
+"""Do nothing, expose models to the REST API as id-only structs (Default behaviour)"""
+	COLLAPSE_MODEL
+"""Expand model field, returning its full data and not just its ID"""
+	EXPAND_MODEL
+"""Drop this field from the REST API"""
+	DROP_FIELD
+}
+
+enum ApiMethod {
+	GET
+	POST
+	PUT
+	PATCH
+	DELETE
+}
 
 """The `Boolean` scalar type represents `true` or `false`."""
 scalar Boolean
@@ -38,19 +156,224 @@ input CLITelemetry {
 	command: CLICommand!
 }
 
+input CertificateCustomization {
+	dnsNames: [String!]
+	ttl: Int
+}
+
+type CertificateInformation {
+	commonName: String!
+	dnsNames: [String!]
+	ttl: Int
+}
+
+enum CertificateProvider {
+	SPIRE
+	CERT_MANAGER
+	CLOUD
+	NONE
+}
+
+type ClientIntentsFileRepresentation {
+	fileName: String!
+	service: Service!
+	rows: [ClientIntentsRow!]!
+	content: String!
+}
+
+type ClientIntentsFiles {
+	files: [ClientIntentsFileRepresentation!]!
+	mergedYAMLFile: MergedYAMLFile
+}
+
+type ClientIntentsRow {
+	text: String!
+	diff: RowDiff
+	calledServerId: ID
+}
+
+type Cluster {
+	id: ID!
+	name: String!
+	configuration: ClusterConfiguration
+	namespaces: [Namespace!]!
+	serviceCount: Int!
+	integration: Integration
+	integrations: [Integration!]!
+	defaultEnvironment: Environment
+	components: IntegrationComponents!
+	createdAt: Time!
+}
+
+type ClusterConfiguration {
+	globalDefaultDeny: Boolean!
+	istioGlobalDefaultDeny: Boolean!
+	useNetworkPoliciesInAccessGraphStates: Boolean!
+	useIstioPoliciesInAccessGraphStates: Boolean!
+	useKafkaACLsInAccessGraphStates: Boolean!
+	clusterFormSettings: ClusterFormSettings!
+}
+
+input ClusterConfigurationInput {
+	globalDefaultDeny: Boolean!
+	istioGlobalDefaultDeny: Boolean
+	useNetworkPoliciesInAccessGraphStates: Boolean!
+	useIstioPoliciesInAccessGraphStates: Boolean
+	useKafkaACLsInAccessGraphStates: Boolean
+	clusterFormSettings: ClusterFormSettingsInput
+}
+
+type ClusterFormSettings {
+	certificateProvider: CertificateProvider!
+	enforcement: Boolean!
+}
+
+input ClusterFormSettingsInput {
+	certificateProvider: CertificateProvider!
+	enforcement: Boolean!
+}
+
 input Component {
-	componentType: ComponentType!
+	componentType: TelemetryComponentType!
 	componentInstanceId: ID!
 	contextId: ID!
 	version: String!
 	cloudClientId: String
 }
 
+type ComponentStatus {
+	type: ComponentStatusType!
+	lastSeen: Time
+}
+
+enum ComponentStatusType {
+	NOT_INTEGRATED
+	CONNECTED
+	DISCONNECTED
+}
+
 enum ComponentType {
 	INTENTS_OPERATOR
 	CREDENTIALS_OPERATOR
 	NETWORK_MAPPER
-	CLI
+}
+
+type CredentialsOperatorComponent {
+	type: ComponentType!
+	status: ComponentStatus!
+}
+
+"""The set of custom constraints supported by our API schema."""
+enum CustomConstraint {
+	CUSTOM_NAME
+	K8S_NAME
+	LABEL_NAME
+	NONEMPTY
+	ID
+}
+
+enum DBPermissionChange {
+	APPLY
+	DELETE
+}
+
+type DatabaseConfig {
+	dbname: String!
+	table: String!
+	operations: [DatabaseOperation!]
+}
+
+input DatabaseConfigInput {
+	dbname: String!
+	table: String!
+	operations: [DatabaseOperation!]!
+}
+
+input DatabaseCredentialsInput {
+	username: String!
+	password: String!
+}
+
+type DatabaseInfo {
+	address: String!
+	databaseType: DatabaseType!
+}
+
+input DatabaseInfoInput {
+	address: String!
+	databaseType: DatabaseType!
+	credentials: DatabaseCredentialsInput!
+}
+
+enum DatabaseOperation {
+	ALL
+	SELECT
+	INSERT
+	UPDATE
+	DELETE
+}
+
+enum DatabaseType {
+	POSTGRESQL
+}
+
+input DiscoveredIntentInput {
+	discoveredAt: Time!
+	intent: IntentInput!
+}
+
+type EdgeAccessStatus {
+	useNetworkPoliciesInAccessGraphStates: Boolean!
+	useIstioPoliciesInAccessGraphStates: Boolean!
+	useKafkaPoliciesInAccessGraphStates: Boolean!
+	verdict: EdgeAccessStatusVerdict!
+	reason: EdgeAccessStatusReason!
+	reasons: [EdgeAccessStatusReason!]!
+}
+
+enum EdgeAccessStatusReason {
+	ALLOWED_BY_APPLIED_INTENTS
+	ALLOWED_BY_APPLIED_INTENTS_OVERLY_PERMISSIVE
+	ALLOWED_BY_APPLIED_INTENTS_HTTP_OVERLY_PERMISSIVE
+	ALLOWED_BY_APPLIED_INTENTS_KAFKA_OVERLY_PERMISSIVE
+	ALLOWED_BY_EXTERNAL_TRAFFIC_NETWORK_POLICY
+	BLOCKED_BY_APPLIED_INTENTS_UNDER_PERMISSIVE
+	BLOCKED_BY_APPLIED_INTENTS_RESOURCE_MISMATCH
+	BLOCKED_BY_APPLIED_INTENTS_HTTP_UNDER_PERMISSIVE
+	BLOCKED_BY_APPLIED_INTENTS_HTTP_RESOURCE_MISMATCH
+	BLOCKED_BY_APPLIED_INTENTS_KAFKA_UNDER_PERMISSIVE
+	BLOCKED_BY_APPLIED_INTENTS_KAFKA_RESOURCE_MISMATCH
+	BLOCKED_BY_KAFKA_ENFORCEMENT_CONFIG_MISSING_APPLIED_INTENTS
+	BLOCKED_BY_DEFAULT_DENY
+	SHARED_SERVICE_ACCOUNT
+	CLIENT_ISTIO_SIDECAR_MISSING
+	SERVER_ISTIO_SIDECAR_MISSING
+	INTENTS_OPERATOR_NOT_ENFORCING
+	INTENTS_OPERATOR_NOT_ENFORCING_MISSING_APPLIED_INTENT
+	INTENTS_OPERATOR_NOT_ENFORCING_KAFKA_INTENTS_NOT_REQUIRED_FOR_TOPIC
+	MISSING_APPLIED_INTENT
+	NOT_IN_PROTECTED_SERVICES
+	INTENTS_OPERATOR_NEVER_CONNECTED
+	NETWORK_MAPPER_NEVER_CONNECTED
+	NO_INTENTS_FOUND_OF_RELEVANT_TYPE
+	IGNORED_IN_CALCULATION
+}
+
+enum EdgeAccessStatusVerdict {
+	EXPLICITLY_ALLOWED
+	IMPLICITLY_ALLOWED
+	WOULD_BE_BLOCKED
+	BLOCKED
+	UNKNOWN
+}
+
+type Environment {
+	id: ID!
+	name: String!
+	labels: [Label!]
+	namespaces: [Namespace!]!
+	serviceCount: Int!
+	appliedIntentsCount: Int!
 }
 
 enum EventType {
@@ -85,13 +408,417 @@ enum EventType {
 """The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](http://en.wikipedia.org/wiki/IEEE_floating_point)."""
 scalar Float
 
+type HTTPConfig {
+	path: String!
+	methods: [HTTPMethod!]
+}
+
+input HTTPConfigInput {
+	path: String!
+	methods: [HTTPMethod!]
+}
+
+enum HTTPMethod {
+	GET
+	POST
+	PUT
+	DELETE
+	OPTIONS
+	TRACE
+	PATCH
+	CONNECT
+	ALL
+}
+
 """The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as "4") or integer (such as 4) input value will be accepted as an ID."""
 scalar ID
+
+input InputAccessGraphFilter {
+	environmentIds: [ID!]
+	clusterIds: [ID!]
+	serviceIds: [ID!]
+	namespaceIds: [ID!]
+	lastSeenAfter: Time
+	includeServicesWithNoEdges: Boolean
+}
 
 """The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1."""
 scalar Int
 
+type Integration {
+	id: ID!
+	name: String!
+	type: IntegrationType!
+	credentials: IntegrationCredentials!
+	components: IntegrationComponents
+	defaultEnvironment: Environment
+	cluster: Cluster
+	databaseInfo: DatabaseInfo
+	awsInfo: AWSInfo
+}
+
+type IntegrationComponents {
+	intentsOperator: IntentsOperatorComponent!
+	credentialsOperator: CredentialsOperatorComponent!
+	networkMapper: NetworkMapperComponent!
+}
+
+type IntegrationCredentials {
+	clientId: String!
+	clientSecret: String!
+}
+
+enum IntegrationType {
+	GENERIC
+	KUBERNETES
+	DATABASE
+	AWS
+}
+
+type Intent {
+	id: ID!
+	server: Service!
+	client: Service!
+	type: IntentType
+	kafkaTopics: [KafkaConfig!]
+	httpResources: [HTTPConfig!]
+	databaseResources: [DatabaseConfig!]
+	awsActions: [String!]
+	status: IntentStatus
+}
+
+input IntentInput {
+	namespace: String!
+	clientName: String!
+	serverName: String!
+	serverNamespace: String
+	type: IntentType
+	topics: [KafkaConfigInput!]
+	resources: [HTTPConfigInput!]
+	databaseResources: [DatabaseConfigInput!]
+	awsActions: [String!]
+	status: IntentStatusInput
+}
+
+type IntentStatus {
+	serviceAccountName: String!
+	isServiceAccountShared: Boolean!
+	isServerMissingSidecar: Boolean!
+	isClientMissingSidecar: Boolean!
+}
+
+input IntentStatusInput {
+	istioStatus: IstioStatusInput
+}
+
+enum IntentType {
+	HTTP
+	KAFKA
+	DATABASE
+	AWS
+	S3
+}
+
+type IntentsOperatorComponent {
+	type: ComponentType!
+	status: ComponentStatus!
+	configuration: IntentsOperatorConfiguration
+}
+
+type IntentsOperatorConfiguration {
+	globalEnforcementEnabled: Boolean!
+	networkPolicyEnforcementEnabled: Boolean!
+	kafkaACLEnforcementEnabled: Boolean!
+	istioPolicyEnforcementEnabled: Boolean!
+	protectedServicesEnabled: Boolean!
+	protectedServices: [Service!]!
+}
+
+input IntentsOperatorConfigurationInput {
+	globalEnforcementEnabled: Boolean!
+	networkPolicyEnforcementEnabled: Boolean
+	kafkaACLEnforcementEnabled: Boolean
+	istioPolicyEnforcementEnabled: Boolean
+	protectedServicesEnabled: Boolean
+}
+
+type Invite {
+	id: ID!
+	email: String!
+	organization: Organization!
+	inviter: User!
+	created: Time!
+	acceptedAt: Time
+	status: InviteStatus!
+}
+
+enum InviteStatus {
+	PENDING
+	ACCEPTED
+}
+
+input IstioStatusInput {
+	serviceAccountName: String!
+	isServiceAccountShared: Boolean!
+	isServerMissingSidecar: Boolean!
+	isClientMissingSidecar: Boolean!
+}
+
+type KafkaConfig {
+	name: String!
+	operations: [KafkaOperation!]
+}
+
+input KafkaConfigInput {
+	name: String!
+	operations: [KafkaOperation!]
+}
+
+enum KafkaOperation {
+	ALL
+	CONSUME
+	PRODUCE
+	CREATE
+	ALTER
+	DELETE
+	DESCRIBE
+	CLUSTER_ACTION
+	DESCRIBE_CONFIGS
+	ALTER_CONFIGS
+	IDEMPOTENT_WRITE
+}
+
+type KafkaServerConfig {
+	address: String
+	topics: [KafkaTopic!]!
+}
+
+input KafkaServerConfigInput {
+	name: String!
+	namespace: String!
+	address: String!
+	topics: [KafkaTopicInput!]!
+}
+
+type KafkaTopic {
+	clientIdentityRequired: Boolean!
+	intentsRequired: Boolean!
+	pattern: KafkaTopicPattern!
+	topic: String!
+}
+
+input KafkaTopicInput {
+	clientIdentityRequired: Boolean!
+	intentsRequired: Boolean!
+	pattern: KafkaTopicPattern!
+	topic: String!
+}
+
+enum KafkaTopicPattern {
+	LITERAL
+	PREFIX
+}
+
+type KeyPair {
+	keyPEM: String!
+	caPEM: String!
+	certPEM: String!
+	rootCAPEM: String!
+	expiresAt: Int!
+}
+
+type Label {
+	key: String!
+	value: String
+}
+
+input LabelInput {
+	key: String!
+	value: String
+}
+
+type Me {
+"""The logged-in user details."""
+	user: User!
+"""The organizations to which the current logged-in user belongs."""
+	organizations: [Organization!]!
+"""Organizations to which the current logged-in user may join."""
+	invites: [Invite!]!
+"""The organization under which the current user request acts.
+This is selected by the X-Otterize-Organization header,
+or, for users with a single organization, this is that single selected organization."""
+	selectedOrganization: Organization!
+}
+
+type MeMutation {
+"""Register the user defined by the active session token into the otterize users store."""
+	registerUser: Me!
+}
+
+type MergedYAMLFile {
+	fileName: String!
+	rows: [ClientIntentsRow!]!
+	content: String!
+}
+
 type Mutation {
+"""This is just a placeholder since currently GraphQL does not allow empty types"""
+	dummy: Boolean
+"""Register certificate-request details for kubernetes pod owner, returns the service associated with this pod owner"""
+	registerKubernetesPodOwnerCertificateRequest(
+		podOwner: NamespacedPodOwner!
+		certificateCustomization: CertificateCustomization
+	): Service!
+"""Report active pod owners to the cloud, as a result the cloud removes certificate requests of inactive pod owners """
+	reportActiveCertificateRequesters(
+		activePodOwners: [NamespacedPodOwner!]!
+	): Boolean!
+"""Create cluster"""
+	createCluster(
+		name: String!
+	): Cluster!
+"""Delete cluster"""
+	deleteCluster(
+		id: ID!
+	): ID!
+"""Update cluster"""
+	updateCluster(
+		id: ID!
+		name: String
+		configuration: ClusterConfigurationInput
+	): Cluster!
+"""Create a new environment"""
+	createEnvironment(
+		name: String!
+		labels: [LabelInput!]
+	): Environment!
+"""Update environment"""
+	updateEnvironment(
+		id: ID!
+		name: String
+		labels: [LabelInput!]
+	): Environment!
+"""Delete environment"""
+	deleteEnvironment(
+		id: ID!
+	): ID!
+"""Add label to environment"""
+	addEnvironmentLabel(
+		id: ID!
+		label: LabelInput!
+	): Environment!
+"""Remove label from environment"""
+	deleteEnvironmentLabel(
+		id: ID!
+		key: String!
+	): Environment!
+"""Create a new generic integration"""
+	createGenericIntegration(
+		name: String!
+	): Integration
+	createDatabaseIntegration(
+		name: String!
+		databaseInfo: DatabaseInfoInput!
+	): Integration
+	updateDatabaseIntegrationCredentials(
+		integrationId: ID!
+		credentials: DatabaseCredentialsInput!
+	): Boolean!
+"""Create a new Kubernetes integration"""
+	createKubernetesIntegration(
+		environmentId: ID
+		clusterId: ID!
+	): Integration
+"""Create a new AWS integration"""
+	createAWSIntegration(
+		name: String!
+		awsIntegration: AWSInfoInput!
+	): Integration
+"""Update AWS integration"""
+	updateAWSIntegration(
+		id: ID!
+		name: String
+		environmentId: ID
+		awsIntegration: AWSInfoInput
+	): Integration
+"""Update Generic integration"""
+	updateGenericIntegration(
+		id: ID!
+		name: String
+	): Integration
+"""Update Kubernetes integration"""
+	updateKubernetesIntegration(
+		id: ID!
+		environmentId: ID
+	): Integration
+"""Delete integration"""
+	deleteIntegration(
+		id: ID!
+	): ID!
+"""Report integration components status"""
+	reportIntegrationComponentStatus(
+		component: ComponentType!
+	): Boolean!
+	reportIntentsOperatorConfiguration(
+		configuration: IntentsOperatorConfigurationInput!
+	): Boolean!
+	reportDiscoveredIntents(
+		intents: [DiscoveredIntentInput!]!
+	): Boolean!
+	reportAppliedKubernetesIntents(
+		namespace: String!
+		intents: [IntentInput!]!
+	): Boolean!
+	handleDatabaseIntents(
+		intents: [IntentInput!]!
+		action: DBPermissionChange!
+	): Boolean!
+	reportNetworkPolicies(
+		namespace: String!
+		policies: [NetworkPolicyInput!]!
+	): Boolean!
+"""Create user invite"""
+	createInvite(
+		email: String!
+	): Invite!
+"""Delete user invite"""
+	deleteInvite(
+		id: ID!
+	): ID!
+"""Accept user invite"""
+	acceptInvite(
+		id: ID!
+	): Invite!
+	reportKafkaServerConfigs(
+		namespace: String!
+		serverConfigs: [KafkaServerConfigInput!]!
+	): Boolean!
+"""Operate on the current logged-in user"""
+	me: MeMutation!
+"""Associate namespace to environment"""
+	associateNamespaceToEnv(
+		id: ID!
+		environmentId: ID
+	): Namespace!
+"""Create a new organization"""
+	createOrganization(
+		name: String
+	): Organization!
+"""Update organization"""
+	updateOrganization(
+		id: ID!
+		name: String
+		imageURL: String
+	): Organization!
+"""Remove user from organization"""
+	removeUserFromOrganization(
+		id: ID!
+		userId: ID!
+	): ID!
+	reportProtectedServicesSnapshot(
+		namespace: String!
+		services: [ProtectedServiceInput!]!
+	): Boolean!
 	sendTelemetries(
 		telemetries: [TelemetryInput!]!
 	): Boolean!
@@ -100,12 +827,278 @@ type Mutation {
 	): Boolean!
 }
 
+type Namespace {
+	id: ID!
+	name: String!
+	cluster: Cluster!
+	environment: Environment!
+	services: [Service!]!
+	serviceCount: Int!
+}
+
+input NamespacedPodOwner {
+	name: String!
+	namespace: String!
+}
+
+type NetworkMapperComponent {
+	type: ComponentType!
+	status: ComponentStatus!
+}
+
+input NetworkPolicyInput {
+	namespace: String!
+	name: String!
+	serverName: String!
+	externalNetworkTrafficPolicy: Boolean!
+}
+
+type Organization {
+	id: ID!
+	name: String
+	imageURL: String
+}
+
+input ProtectedServiceInput {
+	name: String!
+}
+
 type Query {
+"""This is just a placeholder since currently GraphQL does not allow empty types"""
 	dummy: Boolean
+"""Get access graph"""
+	accessGraph(
+		filter: InputAccessGraphFilter
+	): AccessGraph!
+	serviceClientIntents(
+		id: ID!
+		lastSeenAfter: Time!
+	): ServiceClientIntents!
+"""Get cluster"""
+	cluster(
+		id: ID!
+	): Cluster!
+"""List clusters"""
+	clusters(
+		name: String
+	): [Cluster!]!
+"""Get cluster by filters"""
+	oneCluster(
+		name: String!
+	): Cluster
+	serviceUserAndPassword(
+		service: String!
+		namespace: String!
+	): UserAndPassword!
+"""Get environment"""
+	environment(
+		id: ID!
+	): Environment!
+"""List environments"""
+	environments(
+		name: String
+		labels: [LabelInput!]
+	): [Environment!]!
+"""Get environment by filters"""
+	oneEnvironment(
+		name: String!
+	): Environment!
+"""List integrations"""
+	integrations(
+		name: String
+		integrationType: IntegrationType
+		environmentId: ID
+		clusterId: ID
+	): [Integration!]!
+"""Get integration"""
+	integration(
+		id: ID!
+	): Integration!
+"""Get integration by filters"""
+	oneIntegration(
+		integrationType: IntegrationType
+		environmentId: ID
+		clusterId: ID
+		name: String
+	): Integration!
+	testDatabaseConnection(
+		databaseInfo: DatabaseInfoInput!
+	): TestDatabaseConnectionResponse!
+"""List user invites"""
+	invites(
+		email: String
+		status: InviteStatus
+	): [Invite!]!
+"""Get user invite"""
+	invite(
+		id: ID!
+	): Invite!
+"""Get one user invite"""
+	oneInvite(
+		email: String
+		status: InviteStatus
+	): Invite!
+"""Get information regarding the current logged-in user"""
+	me: Me!
+"""Get namespace"""
+	namespace(
+		id: ID!
+	): Namespace!
+"""List namespaces"""
+	namespaces(
+		environmentId: ID
+		clusterId: ID
+		name: String
+	): [Namespace!]!
+"""Get one namespace"""
+	oneNamespace(
+		environmentId: ID
+		clusterId: ID
+		name: String
+	): Namespace!
+"""List organizations"""
+	organizations: [Organization!]!
+"""Get organization"""
+	organization(
+		id: ID!
+	): Organization!
+"""Get service"""
+	service(
+		id: ID!
+	): Service!
+"""List services"""
+	services(
+		environmentId: ID
+		namespaceId: ID
+		name: String
+	): [Service!]!
+"""Get service by filters"""
+	oneService(
+		environmentId: ID
+		namespaceId: ID
+		name: String
+	): Service
+"""List users"""
+	users: [User!]!
+"""Get user"""
+	user(
+		id: ID!
+	): User!
+}
+
+enum RowDiff {
+	ADDED
+	REMOVED
+}
+
+type ServerBlockingStatus {
+	verdict: ServerBlockingStatusVerdict!
+	reason: ServerBlockingStatusReason!
+}
+
+enum ServerBlockingStatusReason {
+	INTENTS_OPERATOR_NEVER_CONNECTED
+	NETWORK_MAPPER_NEVER_CONNECTED
+	INTENTS_IMPLICITLY_ALLOWED
+	ALL_INTENTS_APPLIED
+	MISSING_APPLIED_INTENTS
+	INTENTS_OPERATOR_NOT_ENFORCING
+}
+
+enum ServerBlockingStatusVerdict {
+	UNKNOWN
+	NOT_BLOCKING
+	WOULD_BLOCK
+	BLOCKING
+}
+
+type ServerProtectionStatus {
+	verdict: ServerProtectionStatusVerdict!
+	reason: ServerProtectionStatusReason!
+}
+
+enum ServerProtectionStatusReason {
+	INTENTS_OPERATOR_NEVER_CONNECTED
+	INTENTS_OPERATOR_NOT_ENFORCING
+	SERVER_HAS_NO_NETWORK_POLICY
+	SERVER_HAS_NO_ISTIO_POLICY
+	SERVER_HAS_NO_ISTIO_SIDECAR
+	PROTECTED_BY_DEFAULT_DENY
+	PROTECTED_BY_SERVER_NETWORK_POLICY
+	PROTECTED_BY_SERVER_ISTIO_POLICY
+	PROTECTED_BY_KAFKA_IDENTITY_REQUIRED_NO_INTENTS_REQUIRED
+	PROTECTED_BY_KAFKA_INTENTS_REQUIRED
+	SERVER_HAS_KAFKASERVERCONFIG_NO_ENFORCEMENT
+	SERVER_HAS_NO_KAFKA_SERVER_CONFIG
+	IGNORED_IN_CALCULATION
+	PROTECTED_BY_DATABASE_INTEGRATION
+	PROTECTED_BY_AWS_IAM_INTEGRATION
+}
+
+enum ServerProtectionStatusVerdict {
+	UNKNOWN
+	UNPROTECTED
+	PROTECTED
+}
+
+type ServerProtectionStatuses {
+	networkPolicies: ServerProtectionStatus!
+	kafkaACLs: ServerProtectionStatus!
+	istioPolicies: ServerProtectionStatus!
+}
+
+type Service {
+	id: ID!
+	name: String!
+	namespace: Namespace
+	environment: Environment!
+"""If service is Kafka, its KafkaServerConfig."""
+	kafkaServerConfig: KafkaServerConfig
+	certificateInformation: CertificateInformation
+	serviceAccount: String
+	awsResource: AWSResource
+	tlsKeyPair: KeyPair!
+}
+
+type ServiceAccessGraph {
+	service: Service!
+	types: [ServiceType!]!
+	accessStatus: ServiceAccessStatus!
+	calls: [AccessGraphEdge!]!
+	serves: [AccessGraphEdge!]!
+}
+
+type ServiceAccessStatus {
+	useNetworkPoliciesInAccessGraphStates: Boolean!
+	useKafkaACLsInAccessGraphStates: Boolean!
+	useIstioPoliciesInAccessGraphStates: Boolean!
+	protectionStatus: ServerProtectionStatus!
+	protectionStatuses: ServerProtectionStatuses!
+	blockingStatus: ServerBlockingStatus!
+	hasAppliedIntents: Boolean!
+}
+
+type ServiceClientIntents {
+	asClient: ClientIntentsFiles
+	asServer: ClientIntentsFiles
+}
+
+enum ServiceType {
+	KUBERNETES
+	KAFKA
+	AWS
+	DATABASE
 }
 
 """The `String`scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."""
 scalar String
+
+enum TelemetryComponentType {
+	INTENTS_OPERATOR
+	CREDENTIALS_OPERATOR
+	NETWORK_MAPPER
+	CLI
+}
 
 input TelemetryData {
 	eventType: EventType!
@@ -115,6 +1108,36 @@ input TelemetryData {
 input TelemetryInput {
 	component: Component!
 	data: TelemetryData!
+}
+
+type TestDatabaseConnectionResponse {
+	success: Boolean!
+	errorMessage: String!
+}
+
+scalar Time
+
+type User {
+	id: ID!
+	email: String!
+	name: String!
+	imageURL: String!
+	authProviderUserId: String!
+}
+
+type UserAndPassword {
+	username: String!
+	password: String!
+}
+
+enum UserErrorType {
+	UNAUTHENTICATED
+	NOT_FOUND
+	INTERNAL_SERVER_ERROR
+	BAD_REQUEST
+	FORBIDDEN
+	CONFLICT
+	BAD_USER_INPUT
 }
 
 


### PR DESCRIPTION
### Description
- Add support to the new database integration type.
- New database integration can be created using `integration create` and supplying the details.
- Database address and masked credentials are now added when needed to `integration get` and `integration list`.