### PR TITLE
Add support for create GitHub integrations

### DIFF
--- a/src/cmd/integrations/create/create-github-integration.go
+++ b/src/cmd/integrations/create/create-github-integration.go
@@ -1,0 +1,17 @@
+package create
+
+import (
+	"github.com/otterize/otterize-cli/src/pkg/output"
+	"github.com/spf13/cobra"
+)
+
+var CreateGithubIntegrationCmd = &cobra.Command{
+	Use:          "github",
+	Short:        "Create a GitHub integration",
+	Args:         cobra.NoArgs,
+	SilenceUsage: true,
+	RunE: func(_ *cobra.Command, args []string) error {
+		output.PrintStdout("To create a GitHub integration, you need to authorize Otterize Cloud on your GitHub account. To do that, use Otterize Cloud at https://app.otterize.com/integrations")
+		return nil
+	},
+}

--- a/src/cmd/integrations/create/create-integration.go
+++ b/src/cmd/integrations/create/create-integration.go
@@ -13,4 +13,5 @@ func init() {
 	CreateIntegrationCmd.AddCommand(CreateKubernetesIntegrationCmd)
 	CreateIntegrationCmd.AddCommand(CreateGenericIntegrationCmd)
 	CreateIntegrationCmd.AddCommand(CreateDatabaseIntegrationCmd)
+	CreateIntegrationCmd.AddCommand(CreateGithubIntegrationCmd)
 }


### PR DESCRIPTION
### Description
Add the create GitHub integration command which prompts the user to add the integration using Otterize Cloud, providing the link.