### PR TITLE
Use default kubectl config loading rules

### DIFF
--- a/src/pkg/kafkamapper/mapper.go
+++ b/src/pkg/kafkamapper/mapper.go
@@ -13,8 +13,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/util/homedir"
-	"path/filepath"
 )
 
 var (
@@ -41,7 +39,14 @@ type Mapper struct {
 }
 
 func NewMapper() (*Mapper, error) {
-	config, err := clientcmd.BuildConfigFromFlags("", filepath.Join(homedir.HomeDir(), ".kube", "config"))
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	// if you want to change the loading rules (which files in which order), you can do so here
+
+	configOverrides := &clientcmd.ConfigOverrides{}
+	// if you want to change override values or bind them to flags, there are methods to help you
+
+	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
+	config, err := kubeConfig.ClientConfig()
 	if err != nil {
 		return nil, err
 	}

--- a/src/pkg/portforwarder/portforwarder.go
+++ b/src/pkg/portforwarder/portforwarder.go
@@ -12,11 +12,9 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/portforward"
 	"k8s.io/client-go/transport/spdy"
-	"k8s.io/client-go/util/homedir"
 	"net/http"
 	"net/url"
 	"os"
-	"path/filepath"
 )
 
 type PortForwarder struct {
@@ -34,7 +32,15 @@ func NewPortForwarder(namespace string, serviceName string, servicePort int) *Po
 }
 
 func (p *PortForwarder) Start(ctx context.Context) (localPort int, err error) {
-	config, err := clientcmd.BuildConfigFromFlags("", filepath.Join(homedir.HomeDir(), ".kube", "config"))
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	// if you want to change the loading rules (which files in which order), you can do so here
+
+	configOverrides := &clientcmd.ConfigOverrides{}
+	// if you want to change override values or bind them to flags, there are methods to help you
+
+	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
+	config, err := kubeConfig.ClientConfig()
+	//config, err := clientcmd.BuildConfigFromFlags("", filepath.Join(homedir.HomeDir(), ".kube", "config"))
 	if err != nil {
 		return 0, err
 	}

--- a/src/pkg/portforwarder/portforwarder.go
+++ b/src/pkg/portforwarder/portforwarder.go
@@ -40,7 +40,6 @@ func (p *PortForwarder) Start(ctx context.Context) (localPort int, err error) {
 
 	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
 	config, err := kubeConfig.ClientConfig()
-	//config, err := clientcmd.BuildConfigFromFlags("", filepath.Join(homedir.HomeDir(), ".kube", "config"))
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
Use default kubectl config loading rules. Prior to this PR, the otterize CLI expected to find the config in `~.kube/config`. Now it abides by the same rules as `kubectl`.