### PR TITLE
Fix bug where mapper list command print line in wrong order when intents have HTTP resources

### DIFF
--- a/src/pkg/intentsoutput/intentslister/lister.go
+++ b/src/pkg/intentsoutput/intentslister/lister.go
@@ -13,10 +13,10 @@ func ListFormattedIntents(intents []v1alpha3.ClientIntents) {
 		for _, call := range intent.GetCallsList() {
 			output.PrintStdout("  - %s in namespace %s", call.GetTargetServerName(), call.GetTargetServerNamespace(intent.GetNamespace()))
 			for _, topic := range call.Topics {
-				output.PrintStderr("    - Kafka topic: %s, operations: %s", topic.Name, topic.Operations)
+				output.PrintStdout("    - Kafka topic: %s, operations: %s", topic.Name, topic.Operations)
 			}
 			for _, resource := range call.HTTPResources {
-				output.PrintStderr("    - path %s, methods: %s", resource.Path, strings.ReplaceAll(fmt.Sprintf("%s", resource.Methods), " ", ","))
+				output.PrintStdout("    - path %s, methods: %s", resource.Path, strings.ReplaceAll(fmt.Sprintf("%s", resource.Methods), " ", ","))
 			}
 		}
 	}


### PR DESCRIPTION
### Description

Until this PR, when printing `otterize mapper list` output the Kafka and HTTP resources would be printed to `stderr` instead of `stdout`, while the intents lines where printed to `stdout`. Since the bugsnag SDK was added, the stderr would be printed in small delay and not synchronously with stdout. This also caused breaks when the user redirect the output of one stream into a file, resulting in only part of the table get printed. This PR use stdout for all the printed lines.
