### PR TITLE
Always export communication to the kubernetes API service as `svc:kubernetes.default`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/otterize/otterize-cli
 
-go 1.22
+go 1.22.1
 
 require (
 	aqwari.net/xml v0.0.0-20210331023308-d9421b293817

--- a/src/pkg/intentsoutput/transform.go
+++ b/src/pkg/intentsoutput/transform.go
@@ -12,6 +12,11 @@ import (
 	"slices"
 )
 
+const (
+	kubernetesAPIServerName      = "kubernetes"
+	kubernetesAPIServerNamespace = "default"
+)
+
 type ServiceKey struct {
 	Name       string
 	Namespace  string
@@ -88,6 +93,10 @@ func sortIntents(intents []v1alpha3.ClientIntents) {
 	}
 }
 
+func isServerKubernetesAPIServer(mapperIntent mapperclient.IntentsIntentsIntent) bool {
+	return mapperIntent.Server.Name == kubernetesAPIServerName && mapperIntent.Server.Namespace == kubernetesAPIServerNamespace
+}
+
 func MapperIntentsToAPIIntents(mapperIntents []mapperclient.IntentsIntentsIntent, distinctByLabelKey string, exportKubernetesService bool) []v1alpha3.ClientIntents {
 	apiIntentsByClientService := make(map[ServiceKey]v1alpha3.ClientIntents, 0)
 	for _, mapperIntent := range mapperIntents {
@@ -95,7 +104,10 @@ func MapperIntentsToAPIIntents(mapperIntents []mapperclient.IntentsIntentsIntent
 		serviceName := mapperIntent.Server.Name
 		if exportKubernetesService && len(mapperIntent.Server.KubernetesService) != 0 {
 			serviceName = fmt.Sprintf("svc:%s", mapperIntent.Server.KubernetesService)
+		} else if isServerKubernetesAPIServer(mapperIntent) {
+			serviceName = fmt.Sprintf("svc:%s", kubernetesAPIServerName)
 		}
+
 		if mapperIntent.Server.Namespace != mapperIntent.Client.Namespace {
 			serviceName = fmt.Sprintf("%s.%s", serviceName, mapperIntent.Server.Namespace)
 		}


### PR DESCRIPTION

### Description

The service named `kubernets.default` is not always backed by a pod. Therefore we prefer to export it as with a `svc:` prefix - so the output intent will always work.
