### PR TITLE
Fix bug where `mapper visualize` could use the wrong target namespace

### DIFF
--- a/src/pkg/intentsoutput/intentsvisualizer/visualizer.go
+++ b/src/pkg/intentsoutput/intentsvisualizer/visualizer.go
@@ -110,7 +110,7 @@ func (v *Visualizer) buildEdges(intents []v2alpha1.ClientIntents) error {
 		clientNS := intent.Namespace
 		clientName := getServiceNameWithNamespace(clientNS, intent.GetWorkloadName())
 		for _, call := range intent.GetTargetList() {
-			targetServiceName := getServiceNameWithNamespace(clientNS, call.GetTargetServerName())
+			targetServiceName := getServiceNameWithNamespace(clientNS, call.GetTargetServerNameAsWritten())
 			_, err := v.graph.CreateEdge(
 				fmt.Sprintf("%s to %s", clientName, targetServiceName),
 				v.nodeCache[clientName],


### PR DESCRIPTION


### Description
Fix bug where mapper visualize could get the wrong target namespace

