### PR TITLE
Support enabling/disabling diff comments in otterize clientintents export

### DIFF
--- a/src/cmd/clientintents/export/export-clientintents.go
+++ b/src/cmd/clientintents/export/export-clientintents.go
@@ -12,9 +12,10 @@ import (
 )
 
 const (
-	OutputLocationKey       = "output"
-	OutputLocationShorthand = "o"
-	OutputTypeKey           = "output-type"
+	OutputLocationKey         = "output"
+	OutputLocationShorthand   = "o"
+	OutputTypeKey             = "output-type"
+	OutputWithDiffCommentsKey = "diff"
 
 	ClustersKey         = "clusters"
 	ClustersShortHand   = "c"
@@ -57,8 +58,11 @@ var ExportClientIntentsCmd = &cobra.Command{
 
 		outputLocation := viper.GetString(OutputLocationKey)
 		outputType := viper.GetString(OutputTypeKey)
+		withDiffComments := viper.GetBool(OutputWithDiffCommentsKey)
 
-		return writeExportedIntents(lo.FromPtr(r.JSON200), outputLocation, outputType)
+		writer := NewIntentsWriter(outputLocation, outputType, withDiffComments)
+
+		return writer.WriteExportedIntents(lo.FromPtr(r.JSON200))
 	},
 }
 
@@ -85,6 +89,7 @@ func servicesFilterFromFlags() cloudapi.InputServiceFilter {
 func init() {
 	ExportClientIntentsCmd.Flags().StringP(OutputLocationKey, OutputLocationShorthand, "", "file or dir path to write the output into")
 	ExportClientIntentsCmd.Flags().String(OutputTypeKey, OutputTypeSingleFile, fmt.Sprintf("whether to write output to file or dir: %s/%s", OutputTypeSingleFile, OutputTypeDirectory))
+	ExportClientIntentsCmd.Flags().Bool(OutputWithDiffCommentsKey, false, "include applied vs discovered comments in output intents")
 
 	ExportClientIntentsCmd.Flags().StringSliceP(ClustersKey, ClustersShortHand, nil, "filter for specific clusters")
 	ExportClientIntentsCmd.Flags().StringSliceP(NamespacesKey, NamespacesShorthand, nil, "filter for specific namespaces")

--- a/src/pkg/output/formatters.go
+++ b/src/pkg/output/formatters.go
@@ -237,8 +237,8 @@ func FormatServices(services []cloudapi.Service) {
 	PrintFormatList(services, "services", columns, getColumnData)
 }
 
-func formatRow(row cloudapi.ClientIntentsRow) string {
-	if row.Diff == nil {
+func formatRow(row cloudapi.ClientIntentsRow, withDiffComments bool) string {
+	if !withDiffComments || row.Diff == nil {
 		return row.Text
 	}
 
@@ -252,12 +252,12 @@ func formatRow(row cloudapi.ClientIntentsRow) string {
 	}
 }
 
-func FormatClientIntentsFiles(clientIntentsFiles []cloudapi.ClientIntentsFileRepresentation) string {
+func FormatClientIntentsFiles(clientIntentsFiles []cloudapi.ClientIntentsFileRepresentation, withDiffComments bool) string {
 	contents := lo.Map(clientIntentsFiles, func(file cloudapi.ClientIntentsFileRepresentation, _ int) string {
 		header := fmt.Sprintf("# ClientIntents for Otterize service ID %s; filename: %s", file.Service.Id, file.FileName)
 
 		rows := lo.Map(file.Rows, func(row cloudapi.ClientIntentsRow, _ int) string {
-			return formatRow(row)
+			return formatRow(row, withDiffComments)
 		})
 
 		all := append([]string{header}, rows...)


### PR DESCRIPTION
### Description
This PR adds support for enabling/disabling applied-discovered diff comments in `otterize clientintents export` cli command, using the `--diff` flag (default to false). 

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
