### PR TITLE
Support exporting ClientIntents in version v2 in 'otterize clientintents export' command

### DIFF
--- a/src/cmd/clientintents/export/export-clientintents.go
+++ b/src/cmd/clientintents/export/export-clientintents.go
@@ -15,6 +15,10 @@ const (
 	OutputLocationKey       = "output"
 	OutputLocationShorthand = "o"
 	OutputTypeKey           = "output-type"
+	OutputVersionKey          = "output-version"
+	OutputVersionShortHand    = "v"
+	OutputVersionV1           = "v1"
+	OutputVersionV2           = "v2"
 
 	ClustersKey         = "clusters"
 	ClustersShortHand   = "c"
@@ -45,11 +49,16 @@ var ExportClientIntentsCmd = &cobra.Command{
 			filter.ServiceIds = lo.ToPtr(append(lo.FromPtr(filter.ServiceIds), serviceID))
 		}
 
+		featureFlags := cloudapi.InputFeatureFlags{}
+		if viper.GetString(OutputVersionKey) == OutputVersionV2 {
+			featureFlags.UseClientIntentsV2 = lo.ToPtr(true)
+		}
+
 		r, err := c.ClientIntentsQueryWithResponse(ctxTimeout, cloudapi.ClientIntentsQueryJSONRequestBody{
 			ClusterIds:    filter.ClusterIds,
 			Filter:        filter,
 			LastSeenAfter: nil,
-			FeatureFlags:  nil,
+			FeatureFlags:  &featureFlags,
 		})
 		if err != nil {
 			return err
@@ -85,6 +94,7 @@ func servicesFilterFromFlags() cloudapi.InputServiceFilter {
 func init() {
 	ExportClientIntentsCmd.Flags().StringP(OutputLocationKey, OutputLocationShorthand, "", "file or dir path to write the output into")
 	ExportClientIntentsCmd.Flags().String(OutputTypeKey, OutputTypeSingleFile, fmt.Sprintf("whether to write output to file or dir: %s/%s", OutputTypeSingleFile, OutputTypeDirectory))
+	ExportClientIntentsCmd.Flags().StringP(OutputVersionKey, OutputVersionShortHand, OutputVersionV1, fmt.Sprintf("Output ClientIntents api version - %s/%s", OutputVersionV1, OutputVersionV2))
 
 	ExportClientIntentsCmd.Flags().StringSliceP(ClustersKey, ClustersShortHand, nil, "filter for specific clusters")
 	ExportClientIntentsCmd.Flags().StringSliceP(NamespacesKey, NamespacesShorthand, nil, "filter for specific namespaces")

--- a/src/pkg/cloudclient/graphql/schema.graphql
+++ b/src/pkg/cloudclient/graphql/schema.graphql
@@ -603,6 +603,7 @@ enum EdgeAccessStatusReason {
 	INTENTS_OPERATOR_NOT_ENFORCING_MISSING_APPLIED_INTENT
 	INTENTS_OPERATOR_NOT_ENFORCING_KAFKA_INTENTS_NOT_REQUIRED_FOR_TOPIC
 	MISSING_APPLIED_INTENT
+	MISSING_APPLIED_CLOUD_RESOURCE_INTENT
 	NOT_IN_PROTECTED_SERVICES
 	INTENTS_OPERATOR_NEVER_CONNECTED
 	NETWORK_MAPPER_NEVER_CONNECTED
@@ -710,15 +711,20 @@ input ExternallyManagedPolicyWorkloadInput {
 type FeatureFlags {
 	isCloudServicesDetectionEnabled: Boolean
 	isCloudSecurityEnabled: Boolean
+	useClientIntentsV2: Boolean
 }
 
 type Finding {
 	hash: String!
 	service: BasicEntity!
+	serviceNamespace: BasicEntity
 	server: BasicEntity!
 	cluster: BasicEntity!
+	intentsOperatorState: IntentsOperatorState
+	clusterRelatedServices: [Service!]
 	reason: String!
 	status: FindingStatus!
+	ignoredReason: String
 	type: FindingType!
 }
 
@@ -973,6 +979,7 @@ input InputAccessLogFilter {
 input InputFeatureFlags {
 	isCloudServicesDetectionEnabled: Boolean
 	isCloudSecurityEnabled: Boolean
+	useClientIntentsV2: Boolean
 }
 
 """ Findings filter """
@@ -993,6 +1000,8 @@ input InputFindingFilter {
 	environmentIds: InputIDFilterValue
 """ Findings filter """
 	findingTypes: InputIDFilterValue
+""" Findings filter """
+	hashes: InputIDFilterValue
 }
 
 input InputIDFilterValue {
@@ -1604,8 +1613,15 @@ type Mutation {
 		component: Component
 		errors: [Error!]!
 	): Boolean!
-	toggleIgnoreFindings(
+	setFindingsIgnoredByHashes(
 		hashes: [String!]!
+		ignored: Boolean!
+		reason: String
+	): Boolean!
+	setFindingsIgnoredByControlIds(
+		controlIds: [RegulationCode!]!
+		ignored: Boolean!
+		reason: String
 	): Boolean!
 """Create a new generic integration"""
 	createGenericIntegration(
@@ -1801,11 +1817,6 @@ type Mutation {
 		id: ID!
 		userId: ID!
 	): ID!
-"""Ignore domain for organization"""
-	ignoreOrganizationDomain(
-		id: ID!
-		domain: String!
-	): Organization!
 	reportProtectedServicesSnapshot(
 		namespace: String!
 		services: [ProtectedServiceInput!]!
@@ -1980,6 +1991,13 @@ type Query {
 		enableInternetIntents: Boolean
 		featureFlags: InputFeatureFlags
 	): ServiceClientIntents!
+""" Get service ClientIntents by filter """
+	clientIntents(
+		filter: InputServiceFilter!
+		lastSeenAfter: Time
+		clusterIds: [ID!]
+		featureFlags: InputFeatureFlags
+	): [ClientIntentsFileRepresentation!]!
 """Get access log"""
 	accessLog(
 		filter: InputAccessLogFilter

--- a/src/pkg/cloudclient/restapi/cloudapi/api.gen.go
+++ b/src/pkg/cloudclient/restapi/cloudapi/api.gen.go
@@ -20,7 +20,6 @@ import (
 
 const (
 	AccessTokenCookieScopes  = "accessTokenCookie.Scopes"
-	BearerAuthScopes         = "bearerAuth.Scopes"
 	Oauth2Scopes             = "oauth2.Scopes"
 	OrganizationHeaderScopes = "organizationHeader.Scopes"
 )
@@ -142,6 +141,7 @@ const (
 	EdgeAccessStatusReasonINTENTSOPERATORNOTENFORCINGMISSINGAPPLIEDINTENT            EdgeAccessStatusReason = "INTENTS_OPERATOR_NOT_ENFORCING_MISSING_APPLIED_INTENT"
 	EdgeAccessStatusReasonINTERNETACCESSSTATUSUNKNOWN                                EdgeAccessStatusReason = "INTERNET_ACCESS_STATUS_UNKNOWN"
 	EdgeAccessStatusReasonINTERNETINTENTSENFORCEMENTDISABLED                         EdgeAccessStatusReason = "INTERNET_INTENTS_ENFORCEMENT_DISABLED"
+	EdgeAccessStatusReasonMISSINGAPPLIEDCLOUDRESOURCEINTENT                          EdgeAccessStatusReason = "MISSING_APPLIED_CLOUD_RESOURCE_INTENT"
 	EdgeAccessStatusReasonMISSINGAPPLIEDINTENT                                       EdgeAccessStatusReason = "MISSING_APPLIED_INTENT"
 	EdgeAccessStatusReasonNETWORKMAPPERNEVERCONNECTED                                EdgeAccessStatusReason = "NETWORK_MAPPER_NEVER_CONNECTED"
 	EdgeAccessStatusReasonNOINTENTSFOUNDOFRELEVANTTYPE                               EdgeAccessStatusReason = "NO_INTENTS_FOUND_OF_RELEVANT_TYPE"
@@ -181,6 +181,7 @@ const (
 	EdgeAccessStatusReasonsINTENTSOPERATORNOTENFORCINGMISSINGAPPLIEDINTENT            EdgeAccessStatusReasons = "INTENTS_OPERATOR_NOT_ENFORCING_MISSING_APPLIED_INTENT"
 	EdgeAccessStatusReasonsINTERNETACCESSSTATUSUNKNOWN                                EdgeAccessStatusReasons = "INTERNET_ACCESS_STATUS_UNKNOWN"
 	EdgeAccessStatusReasonsINTERNETINTENTSENFORCEMENTDISABLED                         EdgeAccessStatusReasons = "INTERNET_INTENTS_ENFORCEMENT_DISABLED"
+	EdgeAccessStatusReasonsMISSINGAPPLIEDCLOUDRESOURCEINTENT                          EdgeAccessStatusReasons = "MISSING_APPLIED_CLOUD_RESOURCE_INTENT"
 	EdgeAccessStatusReasonsMISSINGAPPLIEDINTENT                                       EdgeAccessStatusReasons = "MISSING_APPLIED_INTENT"
 	EdgeAccessStatusReasonsNETWORKMAPPERNEVERCONNECTED                                EdgeAccessStatusReasons = "NETWORK_MAPPER_NEVER_CONNECTED"
 	EdgeAccessStatusReasonsNOINTENTSFOUNDOFRELEVANTTYPE                               EdgeAccessStatusReasons = "NO_INTENTS_FOUND_OF_RELEVANT_TYPE"
@@ -789,6 +790,7 @@ type Error struct {
 type FeatureFlags struct {
 	IsCloudSecurityEnabled          *bool `json:"isCloudSecurityEnabled,omitempty"`
 	IsCloudServicesDetectionEnabled *bool `json:"isCloudServicesDetectionEnabled,omitempty"`
+	UseClientIntentsV2              *bool `json:"useClientIntentsV2,omitempty"`
 }
 
 // GCPInfo defines model for GCPInfo.
@@ -903,6 +905,7 @@ type InputAccessLogFilter struct {
 type InputFeatureFlags struct {
 	IsCloudSecurityEnabled          *bool `json:"isCloudSecurityEnabled,omitempty"`
 	IsCloudServicesDetectionEnabled *bool `json:"isCloudServicesDetectionEnabled,omitempty"`
+	UseClientIntentsV2              *bool `json:"useClientIntentsV2,omitempty"`
 }
 
 // InputServiceFilter  Service filter

--- a/src/pkg/cloudclient/restapi/cloudapi/openapi.json
+++ b/src/pkg/cloudclient/restapi/cloudapi/openapi.json
@@ -1329,6 +1329,7 @@
               "INTENTS_OPERATOR_NOT_ENFORCING_MISSING_APPLIED_INTENT",
               "INTENTS_OPERATOR_NOT_ENFORCING_KAFKA_INTENTS_NOT_REQUIRED_FOR_TOPIC",
               "MISSING_APPLIED_INTENT",
+              "MISSING_APPLIED_CLOUD_RESOURCE_INTENT",
               "NOT_IN_PROTECTED_SERVICES",
               "INTENTS_OPERATOR_NEVER_CONNECTED",
               "NETWORK_MAPPER_NEVER_CONNECTED",
@@ -1370,6 +1371,7 @@
                 "INTENTS_OPERATOR_NOT_ENFORCING_MISSING_APPLIED_INTENT",
                 "INTENTS_OPERATOR_NOT_ENFORCING_KAFKA_INTENTS_NOT_REQUIRED_FOR_TOPIC",
                 "MISSING_APPLIED_INTENT",
+                "MISSING_APPLIED_CLOUD_RESOURCE_INTENT",
                 "NOT_IN_PROTECTED_SERVICES",
                 "INTENTS_OPERATOR_NEVER_CONNECTED",
                 "NETWORK_MAPPER_NEVER_CONNECTED",
@@ -1513,6 +1515,9 @@
             "type": "boolean"
           },
           "isCloudServicesDetectionEnabled": {
+            "type": "boolean"
+          },
+          "useClientIntentsV2": {
             "type": "boolean"
           }
         },
@@ -1927,6 +1932,9 @@
             "type": "boolean"
           },
           "isCloudServicesDetectionEnabled": {
+            "type": "boolean"
+          },
+          "useClientIntentsV2": {
             "type": "boolean"
           }
         },
@@ -3507,12 +3515,6 @@
         "name": "access_token",
         "type": "apiKey"
       },
-      "bearerAuth": {
-        "bearerFormat": "JWT",
-        "description": "Otterize user JWT token.",
-        "scheme": "bearer",
-        "type": "http"
-      },
       "oauth2": {
         "description": "Use client ID and client secret from an Otterize integration to authenticate.",
         "flows": {
@@ -3535,7 +3537,7 @@
   "info": {
     "title": "Otterize API Server",
     "version": "v1beta",
-    "x-revision": "69bf2bc7064889412b27dacd1fccb71ed6911b72"
+    "x-revision": "282405d818bdec5386a77301294342aa9f697470"
   },
   "openapi": "3.0.0",
   "paths": {
@@ -8168,12 +8170,6 @@
     },
     {
       "accessTokenCookie": [
-      ],
-      "organizationHeader": [
-      ]
-    },
-    {
-      "bearerAuth": [
       ],
       "organizationHeader": [
       ]

--- a/src/pkg/cloudclient/restapi/generate.go
+++ b/src/pkg/cloudclient/restapi/generate.go
@@ -2,5 +2,5 @@ package restapi
 
 import _ "github.com/deepmap/oapi-codegen/pkg/codegen"
 
-//go:generate curl -s http://localhost:8080/api/rest/v1beta/openapi.json -o ./cloudapi/openapi.json
+//go:generate curl -s https://app.staging.otterize.com/api/rest/v1beta/openapi.json -o ./cloudapi/openapi.json
 //go:generate go run github.com/deepmap/oapi-codegen/cmd/oapi-codegen -o ./cloudapi/api.gen.go --package=cloudapi -generate=types,client ./cloudapi/openapi.json


### PR DESCRIPTION
### Description
This PR adds support for exporting ClientIntents for both version v1 & v2, by passing the `--output-version / -v` flag to `otterize clientintents export`. 
See `otterize clientintents export --help` for more details. 

### Testing
- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist
- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
