### PR TITLE
Include namespace name in generated filenames on otterize clientintents export to dir

### DIFF
--- a/src/cmd/clientintents/export/utils.go
+++ b/src/cmd/clientintents/export/utils.go
@@ -63,18 +63,18 @@ func (w *IntentsWriter) WriteExportedIntents(files []cloudapi.ClientIntentsFileR
 
 func (w *IntentsWriter) filterDuplicateFilenames(files []cloudapi.ClientIntentsFileRepresentation) []cloudapi.ClientIntentsFileRepresentation {
 	filesByFilename := lo.GroupBy(files, func(file cloudapi.ClientIntentsFileRepresentation) string {
-		return file.FileName
+		return file.NamespacedFileName
 	})
 
 	hasUniqueFilename := func(file cloudapi.ClientIntentsFileRepresentation, _ int) bool {
-		return len(filesByFilename[file.FileName]) == 1
+		return len(filesByFilename[file.NamespacedFileName]) == 1
 	}
 	filesWithUniqueFilename := lo.Filter(files, hasUniqueFilename)
 	filesWithDuplicateFilenames := lo.Reject(files, hasUniqueFilename)
 
 	if len(filesWithDuplicateFilenames) > 0 {
 		duplicateFilenames := lo.Uniq(lo.Map(filesWithDuplicateFilenames, func(file cloudapi.ClientIntentsFileRepresentation, _ int) string {
-			return file.FileName
+			return file.NamespacedFileName
 		}))
 		output.PrintStderr("Duplicate filenames detected, omitting the following files:")
 		for _, filename := range duplicateFilenames {
@@ -99,7 +99,7 @@ func (w *IntentsWriter) writeIntentsToDir(dirPath string, files []cloudapi.Clien
 	}
 
 	for _, file := range files {
-		filePath := filepath.Join(dirPath, file.FileName)
+		filePath := filepath.Join(dirPath, file.NamespacedFileName)
 		err := w.writeIntentsToFile(filePath, []cloudapi.ClientIntentsFileRepresentation{file})
 		if err != nil {
 			return err

--- a/src/pkg/cloudclient/graphql/schema.graphql
+++ b/src/pkg/cloudclient/graphql/schema.graphql
@@ -359,6 +359,7 @@ input ClientIntentStatusInput {
 
 type ClientIntentsFileRepresentation {
 	fileName: String!
+	namespacedFileName: String!
 	service: Service!
 	rows: [ClientIntentsRow!]!
 	content: String!
@@ -503,6 +504,11 @@ type DashboardData {
 	overallCompliance: Fraction!
 	nonCompliantStandards: Fraction!
 	nonCompliantControls: Fraction!
+}
+
+type DashboardV2 {
+	dashboard: DashboardData!
+	findings: [FindingSummaryV2!]!
 }
 
 type DatabaseConfig {
@@ -712,6 +718,8 @@ type FeatureFlags {
 	isCloudServicesDetectionEnabled: Boolean
 	isCloudSecurityEnabled: Boolean
 	useClientIntentsV2: Boolean
+	enableFindingsV2: Boolean
+	useTypedIntentsCTE: Boolean
 }
 
 type Finding {
@@ -726,6 +734,7 @@ type Finding {
 	status: FindingStatus!
 	ignoredReason: String
 	type: FindingType!
+	controlId: RegulationCode!
 }
 
 enum FindingStatus {
@@ -767,11 +776,11 @@ type FindingSummaryV2 {
 	description: String!
 	validationDescription: String
 	status: FindingStatus!
-	serviceTotalCount: Int!
-	serviceOpenCount: Int!
-	clusterTotalCount: Int!
-	clusterOpenCount: Int!
+	ignoredReason: String
+	workloadFindingsStatus: StatusSummary!
+	clusterFindingStatus: StatusSummary!
 	requirements: [FindingSummaryV2!]
+	wasOpen: Boolean!
 }
 
 """NEW findings"""
@@ -980,6 +989,8 @@ input InputFeatureFlags {
 	isCloudServicesDetectionEnabled: Boolean
 	isCloudSecurityEnabled: Boolean
 	useClientIntentsV2: Boolean
+	enableFindingsV2: Boolean
+	useTypedIntentsCTE: Boolean
 }
 
 """ Findings filter """
@@ -1166,8 +1177,10 @@ type Intent {
 input IntentInput {
 	namespace: String!
 	clientName: String!
+	clientResolutionData: String
 	clientWorkloadKind: String
 	serverName: String!
+	serverResolutionData: String
 	serverWorkloadKind: String
 	serverAlias: ServerAliasInput
 	serverNamespace: String
@@ -1183,6 +1196,7 @@ input IntentInput {
 	gcpPermissions: [String!]
 	internet: InternetConfigInput
 	status: IntentStatusInput
+	resolutionData: String
 }
 
 type IntentStatus {
@@ -2045,6 +2059,12 @@ type Query {
 	findingStatusHistory(
 		hash: String!
 	): [FindingStatusHistory!]!
+	findingSummaryStatusHistory(
+		leafControlIDs: [RegulationCode!]!
+	): [FindingStatusHistory!]!
+	dashboardV2(
+		filter: InputFindingFilter
+	): DashboardV2!
 """List integrations"""
 	integrations(
 		name: String
@@ -2444,6 +2464,14 @@ input StackFrame {
 	lineNumber: Int!
 	name: String!
 	package: String!
+}
+
+type StatusSummary {
+	openCount: Int!
+	resolvedCount: Int!
+	ignoredCount: Int!
+	totalCount: Int!
+	status: FindingStatus!
 }
 
 """The `String`scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."""

--- a/src/pkg/cloudclient/restapi/cloudapi/api.gen.go
+++ b/src/pkg/cloudclient/restapi/cloudapi/api.gen.go
@@ -577,10 +577,11 @@ type ClientIntentStatus struct {
 
 // ClientIntentsFileRepresentation defines model for ClientIntentsFileRepresentation.
 type ClientIntentsFileRepresentation struct {
-	Content  string             `json:"content"`
-	FileName string             `json:"fileName"`
-	Rows     []ClientIntentsRow `json:"rows"`
-	Service  struct {
+	Content            string             `json:"content"`
+	FileName           string             `json:"fileName"`
+	NamespacedFileName string             `json:"namespacedFileName"`
+	Rows               []ClientIntentsRow `json:"rows"`
+	Service            struct {
 		Id string `json:"id"`
 	} `json:"service"`
 }
@@ -788,9 +789,11 @@ type Error struct {
 
 // FeatureFlags defines model for FeatureFlags.
 type FeatureFlags struct {
+	EnableFindingsV2                *bool `json:"enableFindingsV2,omitempty"`
 	IsCloudSecurityEnabled          *bool `json:"isCloudSecurityEnabled,omitempty"`
 	IsCloudServicesDetectionEnabled *bool `json:"isCloudServicesDetectionEnabled,omitempty"`
 	UseClientIntentsV2              *bool `json:"useClientIntentsV2,omitempty"`
+	UseTypedIntentsCTE              *bool `json:"useTypedIntentsCTE,omitempty"`
 }
 
 // GCPInfo defines model for GCPInfo.
@@ -903,9 +906,11 @@ type InputAccessLogFilter struct {
 
 // InputFeatureFlags defines model for InputFeatureFlags.
 type InputFeatureFlags struct {
+	EnableFindingsV2                *bool `json:"enableFindingsV2,omitempty"`
 	IsCloudSecurityEnabled          *bool `json:"isCloudSecurityEnabled,omitempty"`
 	IsCloudServicesDetectionEnabled *bool `json:"isCloudServicesDetectionEnabled,omitempty"`
 	UseClientIntentsV2              *bool `json:"useClientIntentsV2,omitempty"`
+	UseTypedIntentsCTE              *bool `json:"useTypedIntentsCTE,omitempty"`
 }
 
 // InputServiceFilter  Service filter

--- a/src/pkg/cloudclient/restapi/cloudapi/openapi.json
+++ b/src/pkg/cloudclient/restapi/cloudapi/openapi.json
@@ -790,6 +790,9 @@
           "fileName": {
             "type": "string"
           },
+          "namespacedFileName": {
+            "type": "string"
+          },
           "rows": {
             "items": {
               "$ref": "#/components/schemas/ClientIntentsRow"
@@ -810,6 +813,7 @@
         },
         "required": [
           "fileName",
+          "namespacedFileName",
           "service",
           "rows",
           "content"
@@ -1511,6 +1515,9 @@
       },
       "FeatureFlags": {
         "properties": {
+          "enableFindingsV2": {
+            "type": "boolean"
+          },
           "isCloudSecurityEnabled": {
             "type": "boolean"
           },
@@ -1518,6 +1525,9 @@
             "type": "boolean"
           },
           "useClientIntentsV2": {
+            "type": "boolean"
+          },
+          "useTypedIntentsCTE": {
             "type": "boolean"
           }
         },
@@ -1928,6 +1938,9 @@
       },
       "InputFeatureFlags": {
         "properties": {
+          "enableFindingsV2": {
+            "type": "boolean"
+          },
           "isCloudSecurityEnabled": {
             "type": "boolean"
           },
@@ -1935,6 +1948,9 @@
             "type": "boolean"
           },
           "useClientIntentsV2": {
+            "type": "boolean"
+          },
+          "useTypedIntentsCTE": {
             "type": "boolean"
           }
         },
@@ -3537,7 +3553,7 @@
   "info": {
     "title": "Otterize API Server",
     "version": "v1beta",
-    "x-revision": "282405d818bdec5386a77301294342aa9f697470"
+    "x-revision": "b0ff6bf9ec56bed973c393d950da21da0a90a9b3"
   },
   "openapi": "3.0.0",
   "paths": {

--- a/src/pkg/output/formatters.go
+++ b/src/pkg/output/formatters.go
@@ -254,7 +254,7 @@ func formatRow(row cloudapi.ClientIntentsRow, withDiffComments bool) string {
 
 func FormatClientIntentsFiles(clientIntentsFiles []cloudapi.ClientIntentsFileRepresentation, withDiffComments bool) string {
 	contents := lo.Map(clientIntentsFiles, func(file cloudapi.ClientIntentsFileRepresentation, _ int) string {
-		header := fmt.Sprintf("# ClientIntents for Otterize service ID %s; filename: %s", file.Service.Id, file.FileName)
+		header := fmt.Sprintf("# ClientIntents for Otterize service ID %s; filename: %s", file.Service.Id, file.NamespacedFileName)
 
 		rows := lo.Map(file.Rows, func(row cloudapi.ClientIntentsRow, _ int) string {
 			return formatRow(row, withDiffComments)


### PR DESCRIPTION
### Description
This PR modifies the output format of `otterize clientintents export` when used with `--output-type dir`. The generated output files will now include the namespace name (`client.mynamespace.yaml` rather than just `client.yaml`), to prevent conflicts on workloads with similar names in different namespaces. 

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
