### PR TITLE
Fix an issue where otterize-cli login would fail on users belonging to multiple organizations

### DIFF
--- a/src/pkg/cloudclient/graphql/schema.graphql
+++ b/src/pkg/cloudclient/graphql/schema.graphql
@@ -845,6 +845,7 @@ input ExternalTrafficIntentInput {
 	clientName: String!
 	target: DNSIPPairInput!
 	connectionsCount: ConnectionsCount
+	ttl: Time
 }
 
 input ExternallyAccessibleServiceInput {
@@ -1257,6 +1258,10 @@ input InputNetworkPolicyFilter {
 """ Network policies filter """
 	policyKinds: InputIDFilterValue
 """ Network policies filter """
+	since: InputTimeFilterValue
+}
+
+input InputNetworkPolicyHitsFilter {
 	since: InputTimeFilterValue
 }
 
@@ -2142,9 +2147,10 @@ type Mutation {
 		labels: [LabelInput!]
 	): Boolean!
 	reportNetworkPolicies(
-		namespace: String!
+		namespace: String
 		networkPolicies: [NetworkPolicyInput!]
 	): Boolean!
+	computeNetworkPoliciesForOrg: Boolean!
 """Create a new organization"""
 	createOrganization(
 		name: String
@@ -2203,6 +2209,9 @@ type Mutation {
 	saveOnboardingFeedback(
 		userEmail: String!
 		feedback: String!
+	): Boolean!
+	saveOrgMemberships(
+		memberships: [UserOrgMembershipInput!]!
 	): Boolean!
 	createOrActivateTutorial(
 		tutorialName: TutorialName!
@@ -2273,10 +2282,12 @@ type NetworkPolicy {
 	namespace: Namespace
 	environment: Environment!
 	hits: Int!
+	allowedHits: Int!
+	blockedHits: Int!
 	workloads: [NetworkPolicyWorkload!]!
 	workloadsAffected: Int!
 	spec: String!
-	lastUsed: Time!
+	lastUsed: Time
 }
 
 input NetworkPolicyInput {
@@ -2329,11 +2340,19 @@ type Organization {
 type OrganizationMembership {
 	role: AuthRole!
 	restrictions: OrganizationMembershipRestrictions
+	restrictionResources: OrganizationMembershipRestrictionResources
 }
 
 input OrganizationMembershipInput {
 	role: AuthRole!
 	restrictions: OrganizationMembershipRestrictionsInput
+}
+
+type OrganizationMembershipRestrictionResources {
+	clusters: [Cluster!]!
+	services: [Service!]!
+	namespaces: [Namespace!]!
+	environments: [Environment!]!
 }
 
 type OrganizationMembershipRestrictions {
@@ -2570,6 +2589,7 @@ type Query {
 	): Namespace!
 	networkPolicy(
 		id: ID!
+		filter: InputNetworkPolicyHitsFilter
 	): NetworkPolicy
 	networkPolicies(
 		filter: InputNetworkPolicyFilter
@@ -2623,6 +2643,8 @@ type Query {
 	): TerraformResourceInfo!
 """List users"""
 	users: [User!]!
+"""List users with restriction resources"""
+	orgUsersWithRestrictionResources: UsersWithRestrictionResources!
 	orgUsers: [UserOrganizationAssociation!]!
 """Get user"""
 	user(
@@ -2895,6 +2917,8 @@ input ServiceMetadataInput {
 	tags: [String!]
 	awsRoles: [String!]
 	labels: [LabelInput!]
+	podIps: [String!]
+	serviceIps: [String!]
 }
 
 enum ServiceType {
@@ -3134,6 +3158,11 @@ enum UserErrorType {
 	TIMEOUT
 }
 
+input UserOrgMembershipInput {
+	userId: ID!
+	membership: OrganizationMembershipInput!
+}
+
 type UserOrganizationAssociation {
 	org: Organization!
 	user: User!
@@ -3150,6 +3179,11 @@ type UserTutorial {
 	isCompleted: Boolean!
 	step: String!
 	stepSeen: String!
+}
+
+type UsersWithRestrictionResources {
+	orgUsers: [UserOrganizationAssociation!]!
+	restrictionResources: OrganizationMembershipRestrictionResources
 }
 
 """ Used to validate ID based filters """

--- a/src/pkg/cloudclient/login/userlogin/userlogin.go
+++ b/src/pkg/cloudclient/login/userlogin/userlogin.go
@@ -63,7 +63,7 @@ func (loginCtx *LoginContext) EnsureUserRegistered() error {
 }
 
 func (loginCtx *LoginContext) SelectOrg(preSelectedOrgId string, switchOrg bool) (string, error) {
-	organizations := loginCtx.me.Organizations
+	organizations := loginCtx.me.UserOrganizations
 	selectedOrg := ""
 	if len(organizations) == 0 {
 		orgId, err := loginCtx.createOrJoinOrgFromUserInput()
@@ -73,7 +73,7 @@ func (loginCtx *LoginContext) SelectOrg(preSelectedOrgId string, switchOrg bool)
 		selectedOrg = orgId
 	} else if len(organizations) == 1 {
 		prints.PrintCliStderr("Only 1 organization found - auto-selecting this organization for use.")
-		selectedOrg = organizations[0].Id
+		selectedOrg = organizations[0].Org.Id
 	} else {
 		orgId, err := loginCtx.interactiveSelectOrg(preSelectedOrgId, switchOrg)
 		if err != nil {
@@ -161,7 +161,9 @@ func (loginCtx *LoginContext) createNewOrg() (string, error) {
 }
 
 func (loginCtx *LoginContext) interactiveSelectOrg(preSelectedOrgId string, switchOrg bool) (string, error) {
-	organizations := loginCtx.me.Organizations
+	organizations := lo.Map(loginCtx.me.UserOrganizations, func(userOrg cloudapi.UserOrganizationAssociation, _ int) cloudapi.Organization {
+		return userOrg.Org
+	})
 
 	prints.PrintCliStderr("You belong to the following organizations:")
 	output.FormatOrganizations(organizations)

--- a/src/pkg/cloudclient/restapi/cloudapi/api.gen.go
+++ b/src/pkg/cloudclient/restapi/cloudapi/api.gen.go
@@ -20,6 +20,7 @@ import (
 
 const (
 	AccessTokenCookieScopes  = "accessTokenCookie.Scopes"
+	BearerAuthScopes         = "bearerAuth.Scopes"
 	Oauth2Scopes             = "oauth2.Scopes"
 	OrganizationHeaderScopes = "organizationHeader.Scopes"
 )
@@ -1209,7 +1210,6 @@ type LabelValueTuple struct {
 // Me defines model for Me.
 type Me struct {
 	Invites           []Invite                      `json:"invites"`
-	Organizations     []Organization                `json:"organizations"`
 	User              User                          `json:"user"`
 	UserOrganizations []UserOrganizationAssociation `json:"userOrganizations"`
 }
@@ -1569,10 +1569,8 @@ type User struct {
 // UserOrganizationAssociation defines model for UserOrganizationAssociation.
 type UserOrganizationAssociation struct {
 	Membership OrganizationMembership `json:"membership"`
-	Org        struct {
-		Id string `json:"id"`
-	} `json:"org"`
-	User struct {
+	Org        Organization           `json:"org"`
+	User       struct {
 		Id string `json:"id"`
 	} `json:"user"`
 }

--- a/src/pkg/cloudclient/restapi/cloudapi/openapi.json
+++ b/src/pkg/cloudclient/restapi/cloudapi/openapi.json
@@ -3078,12 +3078,6 @@
             },
             "type": "array"
           },
-          "organizations": {
-            "items": {
-              "$ref": "#/components/schemas/Organization"
-            },
-            "type": "array"
-          },
           "user": {
             "$ref": "#/components/schemas/User",
             "description": "The logged-in user details."
@@ -3097,7 +3091,6 @@
         },
         "required": [
           "user",
-          "organizations",
           "userOrganizations",
           "invites"
         ],
@@ -3224,6 +3217,14 @@
       },
       "NetworkPolicy": {
         "properties": {
+          "allowedHits": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "blockedHits": {
+            "format": "int32",
+            "type": "integer"
+          },
           "cluster": {
             "properties": {
               "id": {
@@ -3301,10 +3302,11 @@
           "cluster",
           "environment",
           "hits",
+          "allowedHits",
+          "blockedHits",
           "workloads",
           "workloadsAffected",
-          "spec",
-          "lastUsed"
+          "spec"
         ],
         "type": "object"
       },
@@ -4362,15 +4364,7 @@
             "$ref": "#/components/schemas/OrganizationMembership"
           },
           "org": {
-            "properties": {
-              "id": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "id"
-            ],
-            "type": "object"
+            "$ref": "#/components/schemas/Organization"
           },
           "user": {
             "properties": {
@@ -4399,6 +4393,12 @@
         "name": "access_token",
         "type": "apiKey"
       },
+      "bearerAuth": {
+        "bearerFormat": "JWT",
+        "description": "Otterize user JWT token.",
+        "scheme": "bearer",
+        "type": "http"
+      },
       "oauth2": {
         "description": "Use client ID and client secret from an Otterize integration to authenticate.",
         "flows": {
@@ -4421,7 +4421,7 @@
   "info": {
     "title": "Otterize API Server",
     "version": "v1beta",
-    "x-revision": "95610758a402a0e201f9daa38874bc3bab3b9877"
+    "x-revision": "c1aac8f2598857722fe628d9b7816e99bb60c9c3"
   },
   "openapi": "3.0.0",
   "paths": {
@@ -9681,6 +9681,12 @@
     },
     {
       "accessTokenCookie": [
+      ],
+      "organizationHeader": [
+      ]
+    },
+    {
+      "bearerAuth": [
       ],
       "organizationHeader": [
       ]

--- a/src/pkg/mapperclient/schema.graphql
+++ b/src/pkg/mapperclient/schema.graphql
@@ -8,6 +8,10 @@ input Destination {
     destinationPort: Int
     TTL: Int
     lastSeen: Time!
+    # It feel like this should belong to RecordedDestinationsForSrc and not the Destination, but we use the source port
+    # only for counting unique connections to to the same destination. By putting it here, we reduce the amount of traffic
+    # we pass from the sniffer to the mapper (this way we can send the src&dest ip only once).
+    srcPorts: [Int!]
 }
 
 input RecordedDestinationsForSrc {
@@ -39,10 +43,24 @@ type GroupVersionKind {
     kind: String!
 }
 
+type IdentityResolutionData {
+    host: String
+    podHostname: String
+    procfsHostname: String
+    port: Int
+    isService: Boolean
+    uptime: String
+    lastSeen: String
+    extraInfo: String
+    hasLinkerdSidecar: Boolean
+}
+
 type OtterizeServiceIdentity {
     name: String!
     namespace: String!
     labels: [PodLabel!]
+    nameResolvedUsingAnnotation: Boolean
+    resolutionData: IdentityResolutionData
     """
     If the service identity was resolved from a pod owner, the GroupVersionKind of the pod owner.
     """
@@ -101,6 +119,7 @@ type Intent {
     client: OtterizeServiceIdentity!
     server: OtterizeServiceIdentity!
     type: IntentType
+    resolutionData: String
     kafkaTopics: [KafkaConfig!]
     httpResources: [HttpResource!]
     awsActions: [String!]
@@ -139,10 +158,24 @@ input IstioConnectionResults {
     results: [IstioConnection!]!
 }
 
+input NamespacedName {
+    name: String!
+    namespace: String!
+}
+
 input AWSOperation {
     resource: String!
     actions: [String!]!
-    srcIp: String!
+    srcIp: String
+    iamRole: String
+    client: NamespacedName
+}
+
+input GCPOperation {
+    resource: String!
+    permissions: [String!]!
+    srcIp: String
+    client: NamespacedName
 }
 
 input ServerFilter {
@@ -156,6 +189,18 @@ input AzureOperation {
     dataActions: [String!]!
     clientName: String!
     clientNamespace: String!
+}
+
+input TrafficLevelResult {
+    srcIP: String!
+    dstIP: String!
+
+    bytesSent: Int!
+    flows: Int!
+}
+
+input TrafficLevelResults {
+    results: [TrafficLevelResult!]!
 }
 
 type Query {
@@ -195,4 +240,6 @@ type Mutation {
     reportIstioConnectionResults(results: IstioConnectionResults!): Boolean!
     reportAWSOperation(operation: [AWSOperation!]!): Boolean!
     reportAzureOperation(operation: [AzureOperation!]!): Boolean!
+    reportGCPOperation(operation: [GCPOperation!]!): Boolean!
+    reportTrafficLevelResults(results: TrafficLevelResults!): Boolean!
 }


### PR DESCRIPTION
### Description
This PR fixes an issue where otterize-cli would fail on login for users belonging to more than one organization, with the following error: 
```
Error: user belongs to multiple organizations, but no organization was specified using the X-Otterize-Organization header (HTTP error 400)
```

### Testing
- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist
- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
