### PR TITLE
Add support for debug logging of HTTP API requests & their duration, by utilizing the OTTERIZE_DEBUD environment variable. 

### DIFF
--- a/src/pkg/cloudclient/restapi/client.go
+++ b/src/pkg/cloudclient/restapi/client.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"net/http"
+	"time"
 )
 
 var ErrNoOrganization = errors.New("no organization exists in config or as parameter")
@@ -86,8 +87,15 @@ type ResponseBody struct {
 }
 
 func (d *doerWithErrorCheck) Do(req *http.Request) (*http.Response, error) {
+	before := time.Now()
 	logrus.WithField("method", req.Method).WithField("url", req.URL).Debug("HTTP request")
 	resp, err := d.doer.Do(req)
+
+	after := time.Now()
+	duration := after.Sub(before)
+	logrus.WithField("method", req.Method).WithField("url", req.URL).
+		WithField("duration", duration).
+		Debug("HTTP request done")
 	if err != nil {
 		return resp, err
 	}


### PR DESCRIPTION
### Description
This PR adds support for debug logging of HTTP requests & their duration, by utilizing the `OTTERIZE_DEBUG` environment variable. 

Usage: 
```
> OTTERIZE_DEBUG=true otterize namespaces list
...

time="2025-04-21T23:08:29+03:00" level=debug msg="HTTP request" method=GET url="http://app.otterize.com/api/rest/v1beta/namespaces"
time="2025-04-21T23:08:56+03:00" level=debug msg="HTTP request done" duration=26.921086583s method=GET url="http://app.otterize.com/api/rest/v1beta/namespaces"
...
```

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR and in github.com/otterize/docs
